### PR TITLE
refactor: 서비스 책임 경계 정제 — MessageData 제거 및 멱등성 처리 분리

### DIFF
--- a/backend/src/main/java/com/maeum/gohyang/communication/adapter/in/web/MessageResponse.java
+++ b/backend/src/main/java/com/maeum/gohyang/communication/adapter/in/web/MessageResponse.java
@@ -1,13 +1,18 @@
 package com.maeum.gohyang.communication.adapter.in.web;
 
-import com.maeum.gohyang.communication.application.port.in.SendMessageUseCase;
+import com.maeum.gohyang.communication.domain.Message;
 
 import java.time.Instant;
 import java.util.UUID;
 
 public record MessageResponse(UUID id, long participantId, String body, Instant createdAt) {
 
-    public static MessageResponse from(SendMessageUseCase.MessageData data) {
-        return new MessageResponse(data.id(), data.participantId(), data.body(), data.createdAt());
+    public static MessageResponse from(Message message) {
+        return new MessageResponse(
+                message.getId(),
+                message.getParticipantId(),
+                message.getBody(),
+                message.getCreatedAt()
+        );
     }
 }

--- a/backend/src/main/java/com/maeum/gohyang/communication/application/port/in/SendMessageUseCase.java
+++ b/backend/src/main/java/com/maeum/gohyang/communication/application/port/in/SendMessageUseCase.java
@@ -1,7 +1,6 @@
 package com.maeum.gohyang.communication.application.port.in;
 
-import java.time.Instant;
-import java.util.UUID;
+import com.maeum.gohyang.communication.domain.Message;
 
 /**
  * 메시지 전송 유스케이스.
@@ -13,7 +12,5 @@ public interface SendMessageUseCase {
 
     record Command(long userId, long chatRoomId, String body) {}
 
-    record Result(MessageData userMessage, MessageData npcMessage) {}
-
-    record MessageData(UUID id, long participantId, String body, Instant createdAt) {}
+    record Result(Message userMessage, Message npcMessage) {}
 }

--- a/backend/src/main/java/com/maeum/gohyang/communication/application/service/SendMessageService.java
+++ b/backend/src/main/java/com/maeum/gohyang/communication/application/service/SendMessageService.java
@@ -4,11 +4,11 @@ import com.maeum.gohyang.communication.application.port.in.SendMessageUseCase;
 import com.maeum.gohyang.communication.application.port.out.GenerateNpcResponsePort;
 import com.maeum.gohyang.communication.application.port.out.LoadParticipantPort;
 import com.maeum.gohyang.communication.application.port.out.SaveMessagePort;
-import com.maeum.gohyang.communication.error.ChatRoomNotFoundException;
 import com.maeum.gohyang.communication.domain.Message;
 import com.maeum.gohyang.communication.domain.MessageType;
-import com.maeum.gohyang.communication.error.NotParticipantException;
 import com.maeum.gohyang.communication.domain.Participant;
+import com.maeum.gohyang.communication.error.ChatRoomNotFoundException;
+import com.maeum.gohyang.communication.error.NotParticipantException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -39,11 +39,6 @@ public class SendMessageService implements SendMessageUseCase {
                 Message.newMessage(command.chatRoomId(), npcParticipant.getId(), npcResponseText, MessageType.TEXT)
         );
 
-        return new Result(toMessageData(userMessage), toMessageData(npcMessage));
-    }
-
-    private MessageData toMessageData(Message message) {
-        return new MessageData(message.getId(), message.getParticipantId(),
-                message.getBody(), message.getCreatedAt());
+        return new Result(userMessage, npcMessage);
     }
 }

--- a/backend/src/main/java/com/maeum/gohyang/global/infra/idempotency/IdempotencyGuard.java
+++ b/backend/src/main/java/com/maeum/gohyang/global/infra/idempotency/IdempotencyGuard.java
@@ -1,0 +1,25 @@
+package com.maeum.gohyang.global.infra.idempotency;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Kafka at-least-once 환경에서 동일 이벤트의 중복 처리를 막는 멱등성 가드.
+ * 이벤트 처리 완료 여부를 processed_event 테이블로 관리한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class IdempotencyGuard {
+
+    private final ProcessedEventJpaRepository repository;
+
+    public boolean isAlreadyProcessed(UUID key) {
+        return repository.existsByEventId(key);
+    }
+
+    public void markAsProcessed(UUID key) {
+        repository.save(ProcessedEventJpaEntity.of(key));
+    }
+}

--- a/backend/src/main/java/com/maeum/gohyang/village/adapter/in/messaging/UserRegisteredEventConsumer.java
+++ b/backend/src/main/java/com/maeum/gohyang/village/adapter/in/messaging/UserRegisteredEventConsumer.java
@@ -4,8 +4,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import com.maeum.gohyang.global.alert.AlertContext;
 import com.maeum.gohyang.global.alert.AlertPort;
-import com.maeum.gohyang.global.infra.idempotency.ProcessedEventJpaEntity;
-import com.maeum.gohyang.global.infra.idempotency.ProcessedEventJpaRepository;
+import com.maeum.gohyang.global.infra.idempotency.IdempotencyGuard;
 import com.maeum.gohyang.village.application.port.in.InitializeUserVillageUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,10 +19,9 @@ import java.util.UUID;
  * user.registered 이벤트를 수신하여 유저의 기본 캐릭터와 공간을 생성한다.
  *
  * 멱등성 처리:
- * - processed_event 테이블에 eventId를 저장하여 동일 이벤트의 중복 처리를 방지한다.
- * - Kafka at-least-once 보장으로 동일 메시지가 재전달될 수 있기 때문이다.
- * - eventId는 Kafka 메시지 헤더의 outbox event_id(UUID)를 key로 사용한다.
- *   메시지 key(userId)가 아닌 이유: 재가입 같은 시나리오에서 동일 userId가 다른 이벤트일 수 있다.
+ * - IdempotencyGuard가 processed_event 테이블 기반으로 중복 처리를 막는다.
+ * - key+offset 조합으로 idempotencyKey를 생성한다.
+ *   (재가입 시나리오에서 동일 userId가 다른 이벤트일 수 있으므로 메시지 key 단독 사용 불가)
  */
 @Slf4j
 @Component
@@ -33,37 +31,38 @@ public class UserRegisteredEventConsumer {
     private static final String TOPIC = "user.registered";
 
     private final InitializeUserVillageUseCase initializeUserVillageUseCase;
-    private final ProcessedEventJpaRepository processedEventJpaRepository;
+    private final IdempotencyGuard idempotencyGuard;
     private final AlertPort alertPort;
     private final ObjectMapper objectMapper;
 
     @KafkaListener(topics = TOPIC)
     @Transactional
     public void handle(ConsumerRecord<String, String> record) {
-        String payload = record.value();
-        log.debug("user.registered 수신: key={} payload={}", record.key(), payload);
-
+        log.debug("user.registered 수신: key={}", record.key());
         try {
-            JsonNode root = objectMapper.readTree(payload);
-            long userId = root.get("userId").asLong();
-            String eventId = record.key() + "-" + record.offset();
-
-            // eventId 기반 멱등성 체크 (outbox event_id를 전달받지 않으므로 key+offset 조합 사용)
-            UUID idempotencyKey = UUID.nameUUIDFromBytes(eventId.getBytes());
-            if (processedEventJpaRepository.existsByEventId(idempotencyKey)) {
-                log.debug("중복 이벤트 무시: eventId={} userId={}", idempotencyKey, userId);
+            var payload = UserRegisteredPayload.from(record, objectMapper);
+            if (idempotencyGuard.isAlreadyProcessed(payload.idempotencyKey())) {
+                log.debug("중복 이벤트 무시: eventId={} userId={}", payload.idempotencyKey(), payload.userId());
                 return;
             }
-
-            initializeUserVillageUseCase.execute(userId);
-            processedEventJpaRepository.save(ProcessedEventJpaEntity.of(idempotencyKey));
-
+            initializeUserVillageUseCase.execute(payload.userId());
+            idempotencyGuard.markAsProcessed(payload.idempotencyKey());
         } catch (Exception e) {
             alertPort.critical(
                     AlertContext.of("village-consumer", record.key(), record.key()),
                     "user.registered 처리 실패: " + e.getMessage()
             );
-            log.error("user.registered 처리 중 오류: payload={} error={}", payload, e.getMessage(), e);
+            log.error("user.registered 처리 중 오류: key={} error={}", record.key(), e.getMessage(), e);
+        }
+    }
+
+    private record UserRegisteredPayload(long userId, UUID idempotencyKey) {
+        static UserRegisteredPayload from(ConsumerRecord<String, String> record, ObjectMapper mapper) throws Exception {
+            JsonNode root = mapper.readTree(record.value());
+            long userId = root.get("userId").asLong();
+            String eventId = record.key() + "-" + record.offset();
+            UUID idempotencyKey = UUID.nameUUIDFromBytes(eventId.getBytes());
+            return new UserRegisteredPayload(userId, idempotencyKey);
         }
     }
 }

--- a/docs/learning/16-hexagonal-refactoring-responsibility.md
+++ b/docs/learning/16-hexagonal-refactoring-responsibility.md
@@ -1,0 +1,181 @@
+# 16. 헥사고날 리팩토링 — 책임 경계가 흐려지는 세 가지 패턴
+
+> Phase 3 완료 후 Cucumber Green 상태에서 수행한 안전한 리팩토링 기록.
+> "돌아가는 코드"를 "의도가 드러나는 코드"로 바꾸는 과정에서 발견한 공통 패턴.
+
+---
+
+## 배경
+
+Happy Path(Phase 0~3)가 Cucumber로 모두 검증된 상태에서 리팩토링을 진행했다.
+테스트가 Green인 상태에서 시작하고, 리팩토링 후 다시 Green인지 검증하는 것이 전제다.
+
+---
+
+## 패턴 1: 중간 DTO 레이어의 함정 — MessageData
+
+### 무슨 일이 있었나
+
+`SendMessageUseCase`에 `MessageData`라는 record가 존재했다.
+
+```java
+// SendMessageUseCase.java
+record MessageData(UUID id, long participantId, String body, Instant createdAt) {}
+record Result(MessageData userMessage, MessageData npcMessage) {}
+```
+
+그리고 `SendMessageService`에는 변환 헬퍼가 있었다.
+
+```java
+// SendMessageService.java
+private MessageData toMessageData(Message message) {
+    return new MessageData(
+        message.getId(), message.getParticipantId(),
+        message.getBody(), message.getCreatedAt()
+    );
+}
+```
+
+### 왜 생겼나
+
+"포트(UseCase 인터페이스)가 도메인 객체를 직접 노출하면 안 된다"는 원칙에서 출발했다.
+도메인이 바뀌어도 포트 계약은 유지되어야 한다는 의도다.
+
+### 왜 잘못됐나
+
+의도는 맞지만, 실제 구현에서 `MessageData`의 필드가 `Message` 도메인과 **완전히 동일**했다.
+변환이 아니라 복사였다. 이름만 다른 똑같은 구조체를 하나 더 만든 것이다.
+
+게다가 `Message`는 순수 POJO다. `@Entity`, `@Table` 같은 인프라 어노테이션이 없다.
+JPA 엔티티(`MessageCassandraEntity`)는 Persistence Adapter 안에 갇혀 있고, Controller가 받는 건
+이미 변환된 도메인 객체다. "도메인 노출"이라는 문제 자체가 이 경우엔 존재하지 않았다.
+
+### 무엇이 달라졌나
+
+```
+Before: Service → Message → MessageData(UseCase) → MessageResponse(Controller)
+After:  Service → Message → MessageResponse(Controller)
+```
+
+`MessageData` 레이어를 제거하고, 변환 책임을 어댑터(Controller)로 이동했다.
+
+```java
+// Before — 서비스가 변환 책임까지 보유
+return new Result(toMessageData(userMessage), toMessageData(npcMessage));
+
+// After — 서비스는 도메인만 반환
+return new Result(userMessage, npcMessage);
+```
+
+```java
+// Before — MessageData를 중간에 거쳐서 변환
+public static MessageResponse from(SendMessageUseCase.MessageData data) {
+    return new MessageResponse(data.id(), data.participantId(), ...);
+}
+
+// After — 어댑터가 도메인에서 직접 변환
+public static MessageResponse from(Message message) {
+    return new MessageResponse(message.getId(), message.getParticipantId(), ...);
+}
+```
+
+### 교훈
+
+중간 DTO 레이어를 만들기 전에 확인할 것:
+- 도메인 객체에 인프라 어노테이션이 있는가? → 있으면 중간 DTO 정당함
+- 변환 로직이 실질적으로 존재하는가? → 복사라면 제거 대상
+- 포트가 실제로 다른 구현체로 교체될 가능성이 있는가? → 없으면 YAGNI
+
+---
+
+## 패턴 2: 어댑터의 private 메서드 — 서비스의 private 메서드와 다르다
+
+### 원칙 오해 주의
+
+"서비스 레이어에서 private 메서드 금지"가 과제 요구사항이었다.
+이것은 **서비스 레이어 한정**이다. 어댑터(Kafka 컨슈머, Controller 등)의 private 메서드는
+다른 맥락이다.
+
+`UserRegisteredEventConsumer`는 어댑터다. 거기에 `UserRegisteredPayload`라는 private inner record를
+만들어 JSON 파싱 로직을 담은 건 private 메서드 금지 원칙과 무관하다. 오히려 권장되는 구조다.
+
+### 왜 어댑터는 다른가
+
+서비스의 private 메서드가 문제인 이유는 **비즈니스 로직을 객체 밖에서 절차적으로 처리**하기 때문이다.
+어댑터의 private 메서드나 inner record는 **인프라 변환 로직을 캡슐화**하는 것이다. 목적이 다르다.
+
+---
+
+## 패턴 3: 어댑터가 인프라 레포지토리를 직접 아는 문제
+
+### 무슨 일이 있었나
+
+`UserRegisteredEventConsumer`(Kafka 어댑터)가 `ProcessedEventJpaRepository`를 직접 주입받고 있었다.
+
+```java
+// Before
+@Component
+public class UserRegisteredEventConsumer {
+    private final ProcessedEventJpaRepository processedEventJpaRepository; // 어댑터가 레포 직접 보유
+
+    public void handle(...) {
+        if (processedEventJpaRepository.existsByEventId(key)) return;
+        initializeUserVillageUseCase.execute(userId);
+        processedEventJpaRepository.save(ProcessedEventJpaEntity.of(key));
+    }
+}
+```
+
+### 왜 문제인가
+
+두 가지 문제가 있었다.
+
+**첫째, 책임 혼재.** `handle()` 메서드가 JSON 파싱, UUID 계산, 중복 체크, 비즈니스 실행, DB 저장을
+전부 순서대로 했다. 읽으면 "무슨 일이 일어나는가"가 보이지 않고, "어떻게 하는가"만 보였다.
+
+**둘째, 복붙 위험.** 새로운 Kafka 토픽이 생길 때마다 멱등성 처리 코드(existsByEventId + save)를
+그대로 복사해야 했다.
+
+### 해결: IdempotencyGuard 분리
+
+```java
+// IdempotencyGuard.java — 멱등성 처리 전담 컴포넌트
+@Component
+public class IdempotencyGuard {
+    public boolean isAlreadyProcessed(UUID key) { ... }
+    public void markAsProcessed(UUID key) { ... }
+}
+```
+
+```java
+// After — handle() 메서드가 비즈니스 의도만 표현
+public void handle(ConsumerRecord<String, String> record) {
+    var payload = UserRegisteredPayload.from(record, objectMapper);
+    if (idempotencyGuard.isAlreadyProcessed(payload.idempotencyKey())) return;
+    initializeUserVillageUseCase.execute(payload.userId());
+    idempotencyGuard.markAsProcessed(payload.idempotencyKey());
+}
+```
+
+**변경 전후 비교:**
+
+| 항목 | 변경 전 | 변경 후 |
+|---|---|---|
+| `handle()` 줄 수 (try 블록 내) | 12줄 | 4줄 |
+| JPA 레포 직접 참조 | 있음 | 없음 (IdempotencyGuard 안에 캡슐화) |
+| 멱등성 로직 재사용 | 불가 (인라인) | 가능 (IdempotencyGuard 주입) |
+| 비즈니스 의도 가독성 | JSON + UUID + DB 로직 혼재 | 흐름만 보임 |
+
+### IdempotencyGuard 위치
+
+`global/infra/idempotency/` 패키지에 배치했다.
+Kafka 도메인 특화가 아니라 어느 어댑터에서도 쓸 수 있는 인프라 공통 컴포넌트이기 때문이다.
+
+---
+
+## 리팩토링 원칙 정리
+
+1. **테스트가 Green인 상태에서만 시작한다.** 테스트가 없으면 리팩토링이 아니라 도박이다.
+2. **"편하니까 여기 놓자"를 경계하라.** 서비스에서 바로 쓰니까 서비스에, 컨슈머에서 쓰니까 컨슈머에 — 이 관성이 책임 혼재를 만든다.
+3. **중간 DTO는 의도가 있어야 한다.** 도메인과 필드가 동일한 DTO는 존재 이유가 없다. 실질적 변환이 없는 DTO는 계층만 늘린다.
+4. **어댑터의 private 메서드 금지와 서비스의 private 메서드 금지는 다른 이유다.** 원칙을 외우지 말고 이유를 이해하라.


### PR DESCRIPTION
## What

### 1. MessageData 중간 레이어 제거 (communication)
- SendMessageUseCase.Result가 MessageData 대신 Message 도메인을 직접 보유
- SendMessageService의 private toMessageData() 헬퍼 제거
- MessageResponse.from(Message)으로 변환 책임을 어댑터(Controller)로 이동

### 2. IdempotencyGuard 신규 컴포넌트 (global/infra/idempotency)
- ProcessedEventJpaRepository 직접 참조를 UserRegisteredEventConsumer에서 분리
- isAlreadyProcessed() / markAsProcessed() 인터페이스로 멱등성 로직 캡슐화
- 향후 다른 Kafka 컨슈머에서도 재사용 가능

### 3. UserRegisteredEventConsumer 책임 분리
- UserRegisteredPayload inner record 도입 (JSON 파싱 + idempotencyKey 계산 캡슐화)
- handle() 메서드: 12줄 → 4줄, 비즈니스 의도만 표현

## Why
- MessageData는 Message와 필드가 완전히 동일한 복사본이었음 (실질적 변환 없음)
- Message는 순수 POJO로 인프라 어노테이션 없음 — 포트 노출 문제 없음
- 어댑터가 JPA 레포를 직접 알면 멱등성 로직이 각 컨슈머에 복붙됨

## Test
Cucumber Happy Path 전체 시나리오 Green 확인 후 진행, 리팩토링 후 재검증 완료