### PR TITLE
fix: CD 자동 배포 정상 순환 — 프로젝트명 고정 + frontend healthcheck 수정

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -14,6 +14,10 @@
 # 환경변수 오버라이드: .env 파일 (이 디렉토리의).
 # 참고: docs/learning/38-env-var-config-migration.md
 
+# compose 파일 위치가 바뀌어도 프로젝트명 고정 → 기존 볼륨·컨테이너 이름 충돌 방지.
+# 이전에 루트에서 돌던 chatappproject 스택과 연속성 유지.
+name: chatappproject
+
 services:
 
   postgres:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -46,7 +46,9 @@ USER gohyang
 
 EXPOSE 3000
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1
+# Alpine busybox wget의 `--spider`가 Next.js 응답과 호환성 문제를 일으키는 케이스가 있어
+# 실제 GET 방식으로 변경. localhost 대신 127.0.0.1 고정으로 IPv6 경로 문제도 회피.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3000/ > /dev/null 2>&1 || exit 1
 
 ENTRYPOINT ["node", "server.js"]


### PR DESCRIPTION
## Summary

PR #16 머지 후 CD 자동 배포가 두 단계에서 실패하는 이슈 해결. 머지되면 이후 모든 main push가 정상 자동 순환한다.

## 증상

### 증상 1 — 컨테이너 이름 충돌
\`\`\`
Error response from daemon: Conflict. The container name "/gohyang-kafka"
is already in use by container "..."
\`\`\`

### 증상 2 — Frontend healthcheck 실패
\`\`\`
docker ps:
  gohyang-frontend   Up 3 minutes (unhealthy)
  gohyang-app        Up 3 minutes (healthy)

docker logs gohyang-frontend:
  ▲ Next.js 16.2.2
  ✓ Ready in 0ms                    ← 정상 기동

curl -I http://localhost:3000/
  HTTP/1.1 200 OK                   ← 응답 정상
\`\`\`

## 원인

### #1 컨테이너 이름 충돌

\`docker-compose.yml\`이 루트 → \`deploy/\`로 이동하며 compose 기본 프로젝트명이 \`chatappproject\` → \`deploy\`로 바뀜. 근데 \`container_name: gohyang-kafka\`는 고정이라 기존 프로젝트 컨테이너와 이름이 충돌.

### #2 Frontend healthcheck wget --spider 호환성

Alpine busybox의 \`wget --spider\`가 Next.js 16.2.2 응답에 대해 정상 판정을 못 하는 케이스. \`curl\`이나 \`wget -qO-\`로는 200 OK 정상 응답. 서비스는 살아있는데 Docker 표시만 unhealthy.

## 수정

### 1. \`deploy/docker-compose.yml\`

\`\`\`yaml
name: chatappproject   # ← 최상단 추가

services:
  ...
\`\`\`

compose 파일 위치가 바뀌어도 프로젝트명 고정. 기존 볼륨(\`chatappproject_postgres_data\` 등) 재사용, 컨테이너 이름 충돌 해소.

### 2. \`frontend/Dockerfile\`

\`\`\`dockerfile
# Before
HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1

# After
HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
  CMD wget -qO- http://127.0.0.1:3000/ > /dev/null 2>&1 || exit 1
\`\`\`

- \`--spider\` 제거 → 실제 GET 수행 (busybox 호환)
- \`localhost\` → \`127.0.0.1\` (IPv6 경로 혼선 방지)
- \`start-period\` 5s → 10s (Next.js 부팅 여유)

## Test plan

- [x] \`docker compose config\` 문법 검증
- [ ] PR 머지 → CD 자동 트리거
- [ ] \`build-frontend\` job 성공 (새 healthcheck 반영된 이미지)
- [ ] \`deploy\` job 성공 (--wait 통과)
- [ ] \`docker ps\` → frontend healthy 표시
- [ ] \`https://ghworld.co\` 브라우저 정상 접속
- [ ] 아무 백엔드 파일 1줄 수정한 테스트 커밋 → CD 정상 순환 확인

## 머지 후 예상 동작

\`\`\`
머지 → CD 자동 트리거
  ↓
build-frontend: 새 healthcheck 반영된 이미지 빌드 → GHCR push
  ↓
build-backend: 변경 없어서 skip
  ↓
deploy job: SSM으로 deploy.sh 실행
  ↓
deploy.sh:
  - git reset --hard <this_sha>
  - compose pull frontend (새 이미지)
  - compose up -d --wait (chatappproject 프로젝트명으로)
    * 기존 컨테이너 그대로 재사용
    * frontend만 새 이미지로 recreate
    * healthcheck 통과 (wget -qO- 성공)
  - 배포 완료
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
- 배포 구성에 프로젝트 이름을 추가하여 컨테이너 및 볼륨 명명 규칙의 일관성 보장
- 컨테이너 헬스 체크 프로브를 개선하고 초기 시작 대기 시간을 조정하여 서비스 모니터링의 정확성 및 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->