### PR TITLE
fix: frontend healthcheck TCP 포트 체크로 전환 (nc -z)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -46,9 +46,10 @@ USER gohyang
 
 EXPOSE 3000
 
-# Alpine busybox wget의 `--spider`가 Next.js 응답과 호환성 문제를 일으키는 케이스가 있어
-# 실제 GET 방식으로 변경. localhost 대신 127.0.0.1 고정으로 IPv6 경로 문제도 회피.
+# HTTP GET 기반 healthcheck(wget/curl)가 Next.js 16 + busybox 조합에서 unhealthy 판정이 반복됨.
+# 실제론 서비스가 200 OK 응답하는데도 실패. 원인 추적 비용이 커서 TCP 포트 체크로 전환.
+# 3000 포트가 열려있으면 Next.js 프로세스가 서빙 준비됐다는 뜻. nc는 busybox 기본 포함.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-  CMD wget -qO- http://127.0.0.1:3000/ > /dev/null 2>&1 || exit 1
+  CMD nc -z 127.0.0.1 3000 || exit 1
 
 ENTRYPOINT ["node", "server.js"]


### PR DESCRIPTION
## Summary

PR #17의 healthcheck 수정이 여전히 unhealthy 판정. Next.js는 정상 응답하는데 wget 기반 체크가 실패. TCP 포트 체크로 단순·안정화.

## 근거

- 유저 EC2에서 확인: \`curl -I http://localhost:3000/\` → HTTP 200 OK (Next.js 정상)
- 근데 \`wget --spider\`도, \`wget -qO-\`도 unhealthy
- 원인은 busybox wget + Next.js 16 HTTP 응답 파싱 이슈로 추정 (정확한 디버깅 시간 부족)
- 근본 원인 파기보다 더 안정적인 방식으로 전환

## 변경

\`\`\`dockerfile
# Before
HEALTHCHECK ... CMD wget -qO- http://127.0.0.1:3000/ > /dev/null 2>&1 || exit 1

# After
HEALTHCHECK ... CMD nc -z 127.0.0.1 3000 || exit 1
\`\`\`

## 트레이드오프

| 항목 | wget HTTP | nc TCP |
|------|-----------|--------|
| 포트 리슨 감지 | ✅ | ✅ |
| HTTP 200 응답 검증 | ✅ | ❌ |
| busybox 호환성 | ⚠ 문제 발생 중 | ✅ 안정 |
| 구현 단순성 | 중간 | 단순 |

HTTP 200 검증은 **nginx 레벨 헬스체크**가 실제 트래픽 경로에서 담당. Docker healthcheck는 주로 compose --wait용 신호이므로 TCP 포트 오픈 확인으로 충분.

## Test plan

- [ ] 머지 → CD 자동 트리거
- [ ] build-frontend 새 이미지 빌드 (TCP healthcheck 적용)
- [ ] deploy job 성공 (--wait 통과)
- [ ] \`docker ps\` → frontend healthy 표시
- [ ] https://ghworld.co 브라우저 정상 접속

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 컨테이너 헬스 체크 메커니즘을 개선했습니다. HTTP 요청 기반 체크에서 포트 가용성 확인 방식으로 변경하여 서비스 상태 감지를 더욱 효율적으로 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->