### PR TITLE
fix(observability): APP_BIND_IP env로 loopback vs VPC scrape 충돌 해소

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -70,6 +70,11 @@ NPC_ADAPTER=hardcoded
 #   엔드포인트만 열면 Spring Security가 인증을 요구해서 Prometheus가 scrape 실패함.
 #   반대로 보안 경로만 풀면 엔드포인트가 존재하지 않아 404가 반환됨.
 #
+# ⚠ APP_BIND_IP 도 운영에선 0.0.0.0 으로 설정해야 VPC 내부 Prometheus가 scrape 가능.
+#   기본값 127.0.0.1(로컬 안전) 그대로 두면 VPC 다른 EC2에서 접근 불가 → scrape 실패.
+#   SG(app-sg)가 monitor-sg만 허용하는 상태면 0.0.0.0 바인딩해도 인터넷 노출은 차단됨.
+#
+# APP_BIND_IP=0.0.0.0
 # ACTUATOR_ENDPOINTS=health,info,metrics,prometheus
 # ACTUATOR_HEALTH_DETAILS=never
 # HEALTH_REDIS_ENABLED=true

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -145,11 +145,14 @@ services:
       context: ../backend
       dockerfile: Dockerfile
     container_name: gohyang-app
-    # 127.0.0.1 바인딩 → 호스트 loopback에만 노출. 인터넷 직접 접근 불가.
-    # nginx가 같은 호스트의 127.0.0.1:8080 으로 프록시하므로 정상 동작.
-    # SG 실수로 포트 열려도 /actuator/** 같은 민감 경로가 외부 노출되지 않는 2중 방어.
+    # APP_BIND_IP로 포트 바인딩 인터페이스를 환경별로 오버라이드.
+    # - 기본값 127.0.0.1: 로컬 개발·CI에서 호스트 loopback만 오픈 (secure by default).
+    #   nginx가 같은 호스트 127.0.0.1:8080으로 프록시하므로 정상 동작.
+    # - 운영 EC2: .env에 APP_BIND_IP=0.0.0.0 설정 (VPC 내부 Prometheus scrape 허용).
+    #   SG(app-sg)가 monitor-sg만 8080 inbound 허용하므로 인터넷 노출은 막힘.
+    # - 더 타이트하게 하려면 APP_BIND_IP=<private-ip> 로 특정 인터페이스만 바인딩 가능.
     ports:
-      - "127.0.0.1:${APP_PORT:-8080}:8080"
+      - "${APP_BIND_IP:-127.0.0.1}:${APP_PORT:-8080}:8080"
     environment:
       # ── Spring 표준 매핑 (자동으로 spring.datasource.url 등에 바인딩) ──
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/gohyang

--- a/docs/learning/40-observability-stack-decisions.md
+++ b/docs/learning/40-observability-stack-decisions.md
@@ -153,12 +153,12 @@ C. security.env-public-paths: /actuator/** → Spring Security permitAll
 
 A+C는 **기존부터 존재**. 이번 PR이 B를 추가해 A+C의 잠재 취약성을 실제 공격 표면으로 전환.
 
-### 해결: 두 층 수정
+### 해결: 두 층 수정 (+ 환경별 오버라이드)
 
 ```yaml
-# 1. 호스트 포트 loopback 바인딩 — SG 실수와 무관한 2중 방어
+# 1. 포트 바인딩 인터페이스를 env로 제어 (환경별 다른 요구 대응)
 ports:
-  - "127.0.0.1:${APP_PORT:-8080}:8080"
+  - "${APP_BIND_IP:-127.0.0.1}:${APP_PORT:-8080}:8080"
 
 # 2. Actuator 기본값 축소 — secure by default
 ACTUATOR_ENDPOINTS: ${ACTUATOR_ENDPOINTS:-health}
@@ -167,9 +167,30 @@ ACTUATOR_ENDPOINTS: ${ACTUATOR_ENDPOINTS:-health}
 운영 `.env`에서 명시적으로 확장:
 
 ```bash
+APP_BIND_IP=0.0.0.0                                              # VPC 내부 scrape 허용
 ACTUATOR_ENDPOINTS=health,info,metrics,prometheus
 SECURITY_ENV_PUBLIC_PATHS=/actuator/health,/actuator/prometheus
 ```
+
+### 왜 `APP_BIND_IP` env화인가 — 시행착오 노트
+
+처음엔 `127.0.0.1`을 **하드코딩**했다 ("loopback 바인딩으로 SG 실수 시 2중 방어").
+그런데 배포 후 monitor EC2의 Prometheus가 `connection refused`.
+
+- 운영 EC2 호스트의 `lo` 인터페이스에만 8080 오픈 → `eth0`(VPC private IP) 8080 닫힘
+- monitor EC2가 VPC 내부 IP로 접근 시도 → 해당 인터페이스에 listener 없음 → refused
+
+**"loopback 2중 방어"와 "VPC 내부 scrape"가 충돌**. 이걸 해결하려고:
+
+- 로컬·CI 환경: 기본값 `127.0.0.1` 유지 (여전히 안전)
+- 운영: `.env`로 `APP_BIND_IP=0.0.0.0` 명시 (SG가 monitor-sg만 허용하니 인터넷 노출은 차단됨)
+- 더 타이트하게 하려면 `APP_BIND_IP=<private-ip>` 로 특정 인터페이스만
+
+교훈:
+
+- "Secure by default"가 **실제 사용 시나리오**를 깨뜨리면 무의미
+- 인프라 결정은 데이터 흐름 전체(app → SG → eth0 → VPC → 다른 EC2)를 그려본 뒤 해야 함
+- env 오버라이드 패턴은 "기본 안전 + 필요 시 개방"의 가장 깔끔한 해답
 
 ### 왜 `health` 하나만 기본값?
 


### PR DESCRIPTION
## Summary

PR #21에서 보안 강화 목적으로 app 포트를 `127.0.0.1:8080:8080`으로 하드코딩했는데, VPC 내부에서 monitor EC2의 Prometheus가 운영 EC2:8080에 접근할 때 `connection refused`가 발생하는 문제 해결.

## 문제

```text
monitor EC2 Prometheus
  → http://gohyang-app:8080/actuator/prometheus 요청
  → extra_hosts 매핑으로 172.31.45.140(운영 EC2 private IP) 로 라우팅
  → TCP connect: 운영 EC2 eth0:8080
  → ❌ connection refused
```

운영 EC2의 8080은 docker가 `lo`(loopback)에만 바인딩 → `eth0`(VPC private IP)에는 listener 없음.

## 해결

```diff
- - "127.0.0.1:${APP_PORT:-8080}:8080"
+ - "${APP_BIND_IP:-127.0.0.1}:${APP_PORT:-8080}:8080"
```

- **기본값** `127.0.0.1`: 로컬·CI 환경 기본 안전 (secure by default 유지)
- **운영** `.env`에서 `APP_BIND_IP=0.0.0.0` 오버라이드 → VPC 내부 scrape 허용
- SG (app-sg)가 monitor-sg만 8080 inbound 허용하므로 인터넷 노출은 계속 차단

## 변경 파일

- `deploy/docker-compose.yml` — ports 바인딩 env화
- `deploy/.env.example` — 운영 APP_BIND_IP 설정 안내 주석 추가
- `docs/learning/40-observability-stack-decisions.md` — "시행착오 노트" 섹션 추가 (근본 원인 + env 오버라이드 패턴 근거)

## Test plan

- [x] 로컬 기본값(127.0.0.1 바인딩) 정상 동작 확인 (기존 흐름 유지)
- [ ] main 머지 후 CD 재배포
- [ ] 운영 EC2의 `deploy/.env`에 `APP_BIND_IP=0.0.0.0` 추가
- [ ] `docker compose up -d app` 재기동 (또는 CD 재배포)
- [ ] monitor Grafana에서 `up{job="gohyang-app"}=1` 전환 확인

## 후속 운영 작업

머지 후 SSM으로 gohyang-server-ko 접속해:

```bash
vi /home/ubuntu/ChatAppProject/deploy/.env
# 맨 위 혹은 관측성 섹션에 추가:
# APP_BIND_IP=0.0.0.0

cd /home/ubuntu/ChatAppProject/deploy
docker compose up -d app
# 또는 CD 재배포 대기
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Prometheus 모니터링을 위한 애플리케이션 바인드 IP 설정 개선
  * 프로덕션 환경에서 Prometheus 스크래핑 접근성 확보
  * 기본값은 로컬 안전성 유지, 운영 환경에서 설정 가능하도록 변경

* **Documentation**
  * 배포 설정 및 환경 변수 문서 업데이트
  * 프로덕션 구성 가이드 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->