### PR TITLE
feat(observability): HTTP/GC histogram + Prometheus remote-write 활성화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ backend/.gradle/
 
 # Claude Code local settings (개인 설정)
 .claude/settings.local.json
+.claude/cache/
 .mcp.json
 
 # Gradle home cache
@@ -45,3 +46,9 @@ backend/.gradle-home/
 pixel-assets-all/
 pixel-assets-all.zip
 frontend/public/assets/
+
+# Load test local artifacts (JWT·결과 민감 정보)
+loadtest/tokens.json
+loadtest/*summary.json
+loadtest/*.log
+loadtest/screenshots/

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ frontend/public/assets/
 
 # Load test local artifacts (JWT·결과 민감 정보)
 loadtest/tokens.json
+loadtest/tokens-errors.json
 loadtest/*summary.json
 loadtest/*.log
 loadtest/screenshots/

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -77,6 +77,18 @@ management:
   metrics:
     tags:
       application: ${MANAGEMENT_METRICS_TAGS_APPLICATION:gohyang-app}
+    # 히스토그램 bucket 노출 — Prometheus histogram_quantile() 로 실제 p95/p99 계산 가능.
+    # 기본 Micrometer는 count/sum/max만 노출해서 histogram_quantile이 No Data 반환.
+    # 여기서 명시적으로 켜야 Grafana에서 proper p95/p99 시계열 그래프 볼 수 있다.
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+        jvm.gc.pause: true
+      # client-side computed percentiles도 함께 노출 (0.5, 0.95, 0.99).
+      # histogram bucket이 해상도 부족할 때 대안 지표로 사용.
+      percentiles:
+        http.server.requests: 0.5, 0.95, 0.99
+        jvm.gc.pause: 0.5, 0.95, 0.99
 
 # 경로 리스트는 콤마 구분 문자열로 env 주입 가능 (Spring이 List<String> 자동 바인딩).
 # - 로컬: swagger 경로 공개 + /actuator/** 전체 허용 (개발 편의)

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,0 +1,115 @@
+# loadtest/ — 마음의 고향 부하 테스트 자산
+
+> k6로 마을 공개 채팅 STOMP broadcast의 breaking point를 찾는다.
+> 상세 설계·STOMP 프레임 설명은 [docs/learning/41-k6-load-testing-setup.md](../docs/learning/41-k6-load-testing-setup.md).
+
+---
+
+## 디렉토리
+
+```text
+loadtest/
+├── lib/
+│   └── stomp.js             # STOMP 프레임 조립/파싱 헬퍼 (재사용)
+├── prepare-tokens.js        # 테스트 계정 사전 발급 (Node 실행, login-first 멱등)
+├── village-mixed.js         # k6 시나리오 — position + chat 혼합 (ramping-vus)
+├── tokens.json              # 발급 결과 (git ignored)
+├── summary.json             # k6 실행 요약 (git ignored)
+└── README.md
+```
+
+## 사전 요구
+
+- k6 ≥ v0.49
+- Node.js ≥ 20 (prepare/cleanup 스크립트용)
+- 백엔드 운영 인스턴스 — `NPC_ADAPTER=hardcoded` 로 임시 전환되어 있을 것
+- (선택) Origin IP 직결 시 EC2 `app-sg`에 테스트 IP 임시 허용
+
+## 실행 순서
+
+### 1) 토큰 풀 발급 (멱등 · 재사용 모델)
+
+```bash
+# 스모크용 소량 먼저 (최초 1회만 register, 이후는 login 재발급)
+BASE_URL=https://ghworld.co COUNT=10 node loadtest/prepare-tokens.js
+
+# 본 테스트용
+BASE_URL=https://ghworld.co COUNT=1000 node loadtest/prepare-tokens.js
+```
+
+- 스크립트는 `login` 먼저 시도 → 401이면 `register`. 같은 이메일을 재사용해도 안전
+- 결과: `loadtest/tokens.json` 에 JWT 배열 저장
+- 계정: `loadtest-0001@test.local` ~ `loadtest-NNNN@test.local` (영구, cleanup 없음)
+- 패스워드 고정: `LoadTest2026!`
+- 동시 요청 수: `CONCURRENCY=10` (환경변수로 조정 가능)
+
+### 2) 스모크 (VU 1, 30초)
+
+```bash
+BASE_URL=https://ghworld.co WS_URL=wss://ghworld.co/ws/websocket \
+  k6 run --vus 1 --duration 30s loadtest/village-mixed.js
+```
+
+통과 기준: `checks` 100%, `ws_connecting` 성공, 서버 로그에 CONNECTED/POSITION broadcast 확인.
+
+### 3) 정식 ramping 테스트
+
+```bash
+BASE_URL=https://ghworld.co WS_URL=wss://ghworld.co/ws/websocket \
+  k6 run --summary-export=loadtest/summary.json \
+  loadtest/village-mixed.js
+```
+
+프로파일(기본): `0 → 50 (1m) → 500 (3m) → 1000 (5m) → 0 (2m)` — 총 ~11분.
+시나리오: position 500ms + chat 15~30s 랜덤. Grafana JVM/HTTP/DB와 **같은 시간축**으로 관찰.
+
+### 4) 수동 가시적 관찰
+
+테스트 실행 중 브라우저로 `https://ghworld.co` 접속 → Phaser 화면에서 유저 캐릭터 이동을 눈으로 확인. VU 100 / 500 / 1000 시점 스크린샷.
+
+### 5) k6 메트릭을 Grafana에 직송 (선택)
+
+k6의 `stomp_connect_latency` 등 클라이언트 관점 메트릭을 Prometheus에 PUSH → Grafana에서 시각화. 공식 대시보드 ID `19665` (k6 Prometheus) 와 매칭.
+
+**전제조건**: 운영 Prometheus가 `--web.enable-remote-write-receiver` 활성화 (monitoring/docker-compose.yml에 반영됨).
+
+**SSM 포트포워딩**으로 monitor EC2의 Prometheus 9090을 로컬로 끌어오기:
+
+```bash
+aws ssm start-session \
+  --target <monitor-ec2-instance-id> \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters "portNumber=9090,localPortNumber=9090" \
+  --region ap-northeast-2
+```
+
+그 상태에서 k6 실행:
+
+```bash
+K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write \
+BASE_URL=https://ghworld.co WS_URL=wss://ghworld.co/ws/websocket \
+  k6 run --out experimental-prometheus-rw \
+  --stage 30s:100 --stage 1m:100 --stage 30s:150 --stage 1m:150 --stage 30s:200 --stage 1m:200 --stage 30s:0 \
+  loadtest/village-mixed.js
+```
+
+**Grafana에 k6 대시보드 import**:
+
+1. Grafana → `+` → Import → Dashboard ID: `19665` → Load
+2. Data source: Prometheus
+3. Load Test Live 옆에 새 탭으로 열어 두고 VU 시점 스크린샷
+
+---
+
+## 주의
+
+- `tokens.json`에는 실 JWT가 들어간다 → **절대 커밋 금지** (`.gitignore` 처리됨).
+- 1000 유저 회원가입은 Outbox → Kafka → 캐릭터/공간 생성 파이프라인을 자극한다. `prepare-tokens.js` 실행 직후 Grafana에서 backlog가 정상 해소되는지 확인 후 본 테스트 진행.
+- Cloudflare 경로 사용 시 부하가 엣지에서 흡수되어 서버 breaking point가 안 드러날 수 있다. 병목 측정 목적이면 Origin IP 직결 권장.
+
+## 참고
+
+- [학습노트 41 — k6 사용법 설계](../docs/learning/41-k6-load-testing-setup.md)
+- [학습노트 40 — 관측성 스택 도입기](../docs/learning/40-observability-stack-decisions.md)
+- [API 명세 — auth](../docs/specs/api/auth.md)
+- [WebSocket 명세](../docs/specs/websocket.md)

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -40,7 +40,8 @@ BASE_URL=https://ghworld.co COUNT=1000 node loadtest/prepare-tokens.js
 - 스크립트는 `login` 먼저 시도 → 401이면 `register`. 같은 이메일을 재사용해도 안전
 - 결과: `loadtest/tokens.json` 에 JWT 배열 저장
 - 계정: `loadtest-0001@test.local` ~ `loadtest-NNNN@test.local` (영구, cleanup 없음)
-- 패스워드 고정: `LoadTest2026!`
+- 패스워드: `LOADTEST_PASSWORD` 환경변수로 오버라이드 (기본값 `LoadTest2026!` — 로컬 dev 편의용).
+  운영/공유 인프라에서는 반드시 env로 주입, 주기적으로 로테이션.
 - 동시 요청 수: `CONCURRENCY=10` (환경변수로 조정 가능)
 
 ### 2) 스모크 (VU 1, 30초)

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -55,13 +55,17 @@ BASE_URL=https://ghworld.co WS_URL=wss://ghworld.co/ws/websocket \
 
 ### 3) 정식 ramping 테스트
 
+**주의**: `village-mixed.js` 는 내부에 `scenarios` 블록이 없다. 따라서 CLI 플래그 없이 `k6 run script.js` 만 하면 k6 기본값(VU 1 · iterations 1)으로 iteration 1회만 돌고 끝난다. **램프 프로파일은 반드시 `--stage` 로 주입**해야 한다.
+
 ```bash
 BASE_URL=https://ghworld.co WS_URL=wss://ghworld.co/ws/websocket \
-  k6 run --summary-export=loadtest/summary.json \
+  k6 run \
+  --stage 1m:50 --stage 3m:500 --stage 5m:1000 --stage 2m:0 \
+  --summary-export=loadtest/summary.json \
   loadtest/village-mixed.js
 ```
 
-프로파일(기본): `0 → 50 (1m) → 500 (3m) → 1000 (5m) → 0 (2m)` — 총 ~11분.
+프로파일(예시): `0 → 50 (1m) → 500 (3m) → 1000 (5m) → 0 (2m)` — 총 ~11분.
 시나리오: position 500ms + chat 15~30s 랜덤. Grafana JVM/HTTP/DB와 **같은 시간축**으로 관찰.
 
 ### 4) 수동 가시적 관찰

--- a/loadtest/lib/stomp.js
+++ b/loadtest/lib/stomp.js
@@ -1,0 +1,56 @@
+// STOMP 1.2 프레임 조립/파싱 헬퍼
+// k6 ws.connect 위에서 직접 STOMP 프레임을 만들어 서버와 주고받는다.
+// 학습노트: docs/learning/41-k6-load-testing-setup.md §4
+
+const NULL = '\x00';
+
+// COMMAND\nheader:value\n\nbody\x00 형태로 조립한다.
+// body 뒤 NULL byte를 빠뜨리면 서버가 프레임을 영원히 기다리므로 반드시 포함.
+export function stompFrame(command, headers = {}, body = '') {
+  const headerLines = Object.entries(headers)
+    .map(([k, v]) => `${k}:${v}`)
+    .join('\n');
+  const headerBlock = headerLines.length > 0 ? `${headerLines}\n` : '';
+  return `${command}\n${headerBlock}\n${body}${NULL}`;
+}
+
+export function parseStompFrame(raw) {
+  const text = raw.endsWith(NULL) ? raw.slice(0, -1) : raw;
+  const sepIdx = text.indexOf('\n\n');
+  if (sepIdx === -1) {
+    return { command: text.trim(), headers: {}, body: '' };
+  }
+  const headerPart = text.slice(0, sepIdx);
+  const body = text.slice(sepIdx + 2);
+  const [command, ...headerLines] = headerPart.split('\n');
+  const headers = {};
+  for (const line of headerLines) {
+    const idx = line.indexOf(':');
+    if (idx === -1) continue;
+    headers[line.slice(0, idx)] = line.slice(idx + 1);
+  }
+  return { command, headers, body };
+}
+
+export const STOMP = {
+  connect: (token, host) =>
+    stompFrame('CONNECT', {
+      'accept-version': '1.2',
+      host,
+      Authorization: `Bearer ${token}`,
+      'heart-beat': '0,0',
+    }),
+
+  subscribe: (id, destination) =>
+    stompFrame('SUBSCRIBE', { id, destination }),
+
+  send: (destination, bodyObj) =>
+    stompFrame(
+      'SEND',
+      { destination, 'content-type': 'application/json' },
+      JSON.stringify(bodyObj),
+    ),
+
+  disconnect: (receipt = 'bye-0') =>
+    stompFrame('DISCONNECT', { receipt }),
+};

--- a/loadtest/lib/stomp.js
+++ b/loadtest/lib/stomp.js
@@ -15,7 +15,10 @@ export function stompFrame(command, headers = {}, body = '') {
 }
 
 export function parseStompFrame(raw) {
-  const text = raw.endsWith(NULL) ? raw.slice(0, -1) : raw;
+  // STOMP 1.2 스펙: EOL 은 [CR] LF — 즉 LF 단독 또는 CRLF 모두 유효.
+  // 정규화로 먼저 \r\n → \n 으로 통일 후 파싱. (1.1 호환 + 브로커 구현체 대응)
+  const normalized = raw.replace(/\r\n/g, '\n');
+  const text = normalized.endsWith(NULL) ? normalized.slice(0, -1) : normalized;
   const sepIdx = text.indexOf('\n\n');
   if (sepIdx === -1) {
     return { command: text.trim(), headers: {}, body: '' };

--- a/loadtest/lib/stomp.js
+++ b/loadtest/lib/stomp.js
@@ -18,7 +18,10 @@ export function parseStompFrame(raw) {
   // STOMP 1.2 스펙: EOL 은 [CR] LF — LF 단독·CRLF 모두 허용.
   // 전체 문자열을 정규화하면 body 안의 CRLF 도 손상되므로,
   // 헤더 영역(blank-line까지)만 regex 로 분리하고 body 는 원본 slice 그대로 반환.
-  const text = raw.endsWith(NULL) ? raw.slice(0, -1) : raw;
+  const withoutNull = raw.endsWith(NULL) ? raw.slice(0, -1) : raw;
+  // 선행 heartbeat (\n 또는 \r\n 반복) 제거 — 서버가 프레임 앞에 keep-alive newline 을
+  // 붙이는 구현이 있어서, 이걸 안 떼면 command 가 빈 문자열로 파싱됨.
+  const text = withoutNull.replace(/^(?:\r?\n)+/, '');
   const sepMatch = text.match(/\r?\n\r?\n/);
   if (!sepMatch) {
     return { command: text.trim(), headers: {}, body: '' };

--- a/loadtest/lib/stomp.js
+++ b/loadtest/lib/stomp.js
@@ -15,22 +15,27 @@ export function stompFrame(command, headers = {}, body = '') {
 }
 
 export function parseStompFrame(raw) {
-  // STOMP 1.2 스펙: EOL 은 [CR] LF — 즉 LF 단독 또는 CRLF 모두 유효.
-  // 정규화로 먼저 \r\n → \n 으로 통일 후 파싱. (1.1 호환 + 브로커 구현체 대응)
-  const normalized = raw.replace(/\r\n/g, '\n');
-  const text = normalized.endsWith(NULL) ? normalized.slice(0, -1) : normalized;
-  const sepIdx = text.indexOf('\n\n');
-  if (sepIdx === -1) {
+  // STOMP 1.2 스펙: EOL 은 [CR] LF — LF 단독·CRLF 모두 허용.
+  // 전체 문자열을 정규화하면 body 안의 CRLF 도 손상되므로,
+  // 헤더 영역(blank-line까지)만 regex 로 분리하고 body 는 원본 slice 그대로 반환.
+  const text = raw.endsWith(NULL) ? raw.slice(0, -1) : raw;
+  const sepMatch = text.match(/\r?\n\r?\n/);
+  if (!sepMatch) {
     return { command: text.trim(), headers: {}, body: '' };
   }
-  const headerPart = text.slice(0, sepIdx);
-  const body = text.slice(sepIdx + 2);
-  const [command, ...headerLines] = headerPart.split('\n');
+  const headerPart = text.slice(0, sepMatch.index);
+  // body 는 원본 그대로 — 바이너리·멀티라인 페이로드의 CRLF 보존.
+  const body = text.slice(sepMatch.index + sepMatch[0].length);
+  const [commandRaw, ...headerLines] = headerPart.split(/\r?\n/);
+  const command = commandRaw.trim();
   const headers = {};
   for (const line of headerLines) {
     const idx = line.indexOf(':');
     if (idx === -1) continue;
-    headers[line.slice(0, idx)] = line.slice(idx + 1);
+    // 헤더 key/value 끝에 붙을 수 있는 \r 만 제거 (value 안쪽 \r 은 보존 불필요, 원래 trim 허용 스펙)
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).replace(/\r$/, '');
+    headers[key] = value;
   }
   return { command, headers, body };
 }

--- a/loadtest/prepare-tokens.js
+++ b/loadtest/prepare-tokens.js
@@ -21,6 +21,16 @@ const path = require('path');
 const BASE_URL = (process.env.BASE_URL || 'http://localhost:8080').replace(/\/$/, '');
 const COUNT = parseInt(process.env.COUNT || '10', 10);
 const CONCURRENCY = parseInt(process.env.CONCURRENCY || '10', 10);
+
+// 음수·0·NaN 입력은 루프 폭주 또는 비정상 종료 유발. fail-fast.
+function assertPositiveInt(name, value) {
+  if (!Number.isInteger(value) || value <= 0) {
+    console.error(`[prepare-tokens] ${name} must be a positive integer (got: ${value})`);
+    process.exit(2);
+  }
+}
+assertPositiveInt('COUNT', COUNT);
+assertPositiveInt('CONCURRENCY', CONCURRENCY);
 const EMAIL_PREFIX = 'loadtest-';
 const EMAIL_DOMAIN = '@test.local';
 // 기본값은 로컬 개발 편의용. 운영/CI에서는 LOADTEST_PASSWORD env 로 오버라이드 권장.
@@ -111,20 +121,28 @@ async function main() {
   });
   process.stdout.write('\n');
 
-  fs.writeFileSync(OUT_FILE, JSON.stringify(tokens, null, 2), 'utf-8');
   const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
 
+  // 부분 실패 시 tokens.json 저장 금지 — 불완전 풀이 오사용되면 일부 VU가
+  // 유효 토큰 없이 돌아 테스트가 "fake breaking point"처럼 보이는 원인이 됨.
+  // 실패 정보는 별도 파일 `tokens-errors.json` 에 기록해 디버깅용.
+  if (errors.length > 0) {
+    const errorFile = OUT_FILE.replace(/tokens\.json$/, 'tokens-errors.json');
+    fs.writeFileSync(errorFile, JSON.stringify(errors, null, 2), 'utf-8');
+    console.log(`\n❌ [prepare-tokens] ${errors.length} error(s) — tokens.json NOT saved`);
+    console.log(`   error details: ${errorFile}`);
+    console.log(`   first 5 errors:`);
+    errors.slice(0, 5).forEach((e) => console.log(`     ${e.email}: ${e.reason}`));
+    console.log(`   elapsed:  ${elapsed}s`);
+    process.exit(1);
+  }
+
+  fs.writeFileSync(OUT_FILE, JSON.stringify(tokens, null, 2), 'utf-8');
   console.log(`\n[prepare-tokens] saved ${tokens.length} tokens → ${OUT_FILE}`);
   console.log(`   login:    ${loginCount}`);
   console.log(`   register: ${registerCount}`);
-  console.log(`   errors:   ${errors.length}`);
+  console.log(`   errors:   0`);
   console.log(`   elapsed:  ${elapsed}s`);
-
-  if (errors.length > 0) {
-    console.log('\n⚠️  first 5 errors:');
-    errors.slice(0, 5).forEach((e) => console.log(`   ${e.email}: ${e.reason}`));
-    process.exit(1);
-  }
 }
 
 main().catch((err) => {

--- a/loadtest/prepare-tokens.js
+++ b/loadtest/prepare-tokens.js
@@ -53,6 +53,7 @@ function emailFor(i) {
 }
 
 const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS || '15000', 10);
+assertPositiveInt('REQUEST_TIMEOUT_MS', REQUEST_TIMEOUT_MS);
 
 async function postJson(endpoint, body) {
   // AbortController 로 per-request timeout — 네트워크 stall 시 배치가 무기한 대기하지 않도록.

--- a/loadtest/prepare-tokens.js
+++ b/loadtest/prepare-tokens.js
@@ -1,12 +1,17 @@
 // 테스트 계정 토큰 풀 발급기 (Node.js >= 18, native fetch 사용).
 //
 // 사용법:
-//   BASE_URL=https://ghworld.co COUNT=10   node loadtest/prepare-tokens.js
-//   BASE_URL=https://ghworld.co COUNT=1000 node loadtest/prepare-tokens.js
+//   # 로컬 dev (default 패스워드 허용)
+//   BASE_URL=http://localhost:8080 COUNT=10 node loadtest/prepare-tokens.js
+//
+//   # 공유/운영 (LOADTEST_PASSWORD env 필수)
+//   BASE_URL=https://ghworld.co LOADTEST_PASSWORD='YourStrongPassword' \
+//     COUNT=1000 node loadtest/prepare-tokens.js
 //
 // 계정 규칙 (재사용 모델 — cleanup 없음):
 //   이메일:   loadtest-0001@test.local ~ loadtest-NNNN@test.local
-//   패스워드: LoadTest2026! (고정)
+//   패스워드: LOADTEST_PASSWORD env 가 우선 (비로컬 BASE_URL 에서는 필수).
+//            미설정 시 LoadTest2026! fallback — localhost/127.0.0.1 에서만 허용.
 //
 // 동작:
 //   1) 각 이메일로 POST /api/v1/auth/login 시도

--- a/loadtest/prepare-tokens.js
+++ b/loadtest/prepare-tokens.js
@@ -33,9 +33,18 @@ assertPositiveInt('COUNT', COUNT);
 assertPositiveInt('CONCURRENCY', CONCURRENCY);
 const EMAIL_PREFIX = 'loadtest-';
 const EMAIL_DOMAIN = '@test.local';
-// 기본값은 로컬 개발 편의용. 운영/CI에서는 LOADTEST_PASSWORD env 로 오버라이드 권장.
-// 테스트 계정은 `@test.local` 도메인 · 일반 유저 권한만 · 실데이터 접근 없음.
-const PASSWORD = process.env.LOADTEST_PASSWORD || 'LoadTest2026!';
+
+// 기본값은 로컬 dev 편의용. 공유/운영 대상에서는 기본값 사용이 공통 자격증명을 만들어
+// 예측 가능한 공격 벡터가 된다. localhost/127.0.0.1 이 아니면 env 강제.
+const isLocalBaseUrl = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/i.test(BASE_URL);
+const envPassword = process.env.LOADTEST_PASSWORD;
+if (!isLocalBaseUrl && !envPassword) {
+  console.error(`[prepare-tokens] LOADTEST_PASSWORD 환경변수가 필요합니다.`);
+  console.error(`   BASE_URL=${BASE_URL} (비로컬) — 기본 비밀번호 fallback 차단.`);
+  console.error(`   예: LOADTEST_PASSWORD='YourStrongPassword' node loadtest/prepare-tokens.js`);
+  process.exit(2);
+}
+const PASSWORD = envPassword || 'LoadTest2026!';
 
 const OUT_FILE = path.join(__dirname, 'tokens.json');
 
@@ -43,19 +52,29 @@ function emailFor(i) {
   return `${EMAIL_PREFIX}${String(i).padStart(4, '0')}${EMAIL_DOMAIN}`;
 }
 
+const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS || '15000', 10);
+
 async function postJson(endpoint, body) {
-  const res = await fetch(`${BASE_URL}${endpoint}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  });
-  let payload = null;
+  // AbortController 로 per-request timeout — 네트워크 stall 시 배치가 무기한 대기하지 않도록.
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   try {
-    payload = await res.json();
-  } catch (_) {
-    payload = null;
+    const res = await fetch(`${BASE_URL}${endpoint}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    let payload = null;
+    try {
+      payload = await res.json();
+    } catch (_) {
+      payload = null;
+    }
+    return { status: res.status, body: payload };
+  } finally {
+    clearTimeout(timeout);
   }
-  return { status: res.status, body: payload };
 }
 
 async function loginOrRegister(email) {

--- a/loadtest/prepare-tokens.js
+++ b/loadtest/prepare-tokens.js
@@ -1,0 +1,133 @@
+// 테스트 계정 토큰 풀 발급기 (Node.js >= 18, native fetch 사용).
+//
+// 사용법:
+//   BASE_URL=https://ghworld.co COUNT=10   node loadtest/prepare-tokens.js
+//   BASE_URL=https://ghworld.co COUNT=1000 node loadtest/prepare-tokens.js
+//
+// 계정 규칙 (재사용 모델 — cleanup 없음):
+//   이메일:   loadtest-0001@test.local ~ loadtest-NNNN@test.local
+//   패스워드: LoadTest2026! (고정)
+//
+// 동작:
+//   1) 각 이메일로 POST /api/v1/auth/login 시도
+//   2) 401이면 POST /api/v1/auth/register
+//   3) 응답의 accessToken 을 loadtest/tokens.json 배열로 저장
+//
+// 2회차부터는 login-only 경로라 Outbox→Kafka→character/space 생성 폭주 없음.
+
+const fs = require('fs');
+const path = require('path');
+
+const BASE_URL = (process.env.BASE_URL || 'http://localhost:8080').replace(/\/$/, '');
+const COUNT = parseInt(process.env.COUNT || '10', 10);
+const CONCURRENCY = parseInt(process.env.CONCURRENCY || '10', 10);
+const EMAIL_PREFIX = 'loadtest-';
+const EMAIL_DOMAIN = '@test.local';
+// 기본값은 로컬 개발 편의용. 운영/CI에서는 LOADTEST_PASSWORD env 로 오버라이드 권장.
+// 테스트 계정은 `@test.local` 도메인 · 일반 유저 권한만 · 실데이터 접근 없음.
+const PASSWORD = process.env.LOADTEST_PASSWORD || 'LoadTest2026!';
+
+const OUT_FILE = path.join(__dirname, 'tokens.json');
+
+function emailFor(i) {
+  return `${EMAIL_PREFIX}${String(i).padStart(4, '0')}${EMAIL_DOMAIN}`;
+}
+
+async function postJson(endpoint, body) {
+  const res = await fetch(`${BASE_URL}${endpoint}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  let payload = null;
+  try {
+    payload = await res.json();
+  } catch (_) {
+    payload = null;
+  }
+  return { status: res.status, body: payload };
+}
+
+async function loginOrRegister(email) {
+  const login = await postJson('/api/v1/auth/login', { email, password: PASSWORD });
+  if (login.status === 200 && login.body?.accessToken) {
+    return { token: login.body.accessToken, source: 'login' };
+  }
+  if (login.status !== 401) {
+    throw new Error(`login ${login.status}: ${JSON.stringify(login.body)}`);
+  }
+  const reg = await postJson('/api/v1/auth/register', { email, password: PASSWORD });
+  if (reg.status === 201 && reg.body?.accessToken) {
+    return { token: reg.body.accessToken, source: 'register' };
+  }
+  throw new Error(`register ${reg.status}: ${JSON.stringify(reg.body)}`);
+}
+
+async function runInBatches(items, batchSize, worker, onProgress) {
+  const out = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    const settled = await Promise.allSettled(batch.map(worker));
+    for (let j = 0; j < settled.length; j++) {
+      const r = settled[j];
+      if (r.status === 'fulfilled') out.push({ ok: true, value: r.value });
+      else out.push({ ok: false, email: batch[j], reason: r.reason?.message || String(r.reason) });
+    }
+    onProgress(out);
+  }
+  return out;
+}
+
+async function main() {
+  const startedAt = Date.now();
+  console.log(`[prepare-tokens] BASE_URL=${BASE_URL}  COUNT=${COUNT}  CONCURRENCY=${CONCURRENCY}`);
+
+  const emails = Array.from({ length: COUNT }, (_, i) => emailFor(i + 1));
+  let loginCount = 0;
+  let registerCount = 0;
+  const tokens = [];
+  const errors = [];
+
+  await runInBatches(
+    emails,
+    CONCURRENCY,
+    async (email) => {
+      const { token, source } = await loginOrRegister(email);
+      if (source === 'login') loginCount++;
+      else registerCount++;
+      tokens.push(token);
+      return { email, source };
+    },
+    (results) => {
+      const done = results.length;
+      process.stdout.write(
+        `\r progress ${done}/${COUNT}  login=${loginCount} register=${registerCount} errors=${results.filter((r) => !r.ok).length}   `,
+      );
+    },
+  ).then((results) => {
+    for (const r of results) {
+      if (!r.ok) errors.push({ email: r.email, reason: r.reason });
+    }
+  });
+  process.stdout.write('\n');
+
+  fs.writeFileSync(OUT_FILE, JSON.stringify(tokens, null, 2), 'utf-8');
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+
+  console.log(`\n[prepare-tokens] saved ${tokens.length} tokens → ${OUT_FILE}`);
+  console.log(`   login:    ${loginCount}`);
+  console.log(`   register: ${registerCount}`);
+  console.log(`   errors:   ${errors.length}`);
+  console.log(`   elapsed:  ${elapsed}s`);
+
+  if (errors.length > 0) {
+    console.log('\n⚠️  first 5 errors:');
+    errors.slice(0, 5).forEach((e) => console.log(`   ${e.email}: ${e.reason}`));
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('\n[prepare-tokens] fatal:', err);
+  process.exit(1);
+});

--- a/loadtest/village-mixed.js
+++ b/loadtest/village-mixed.js
@@ -65,7 +65,16 @@ export default function () {
   if (tokens.length === 0) {
     throw new Error('tokens.json empty — run prepare-tokens.js first');
   }
-  const token = tokens[(__VU - 1) % tokens.length];
+  // 토큰 부족 시 fail-fast — modulus wrap 으로 재사용하면 동일 userId 가
+  // 여러 VU 에서 동시 접속해 세션 축출·presence 덮어쓰기로 결과가 왜곡됨.
+  // 풀 부족은 prepare-tokens.js COUNT 를 VU max 이상으로 맞춰 해결.
+  if (__VU > tokens.length) {
+    throw new Error(
+      `insufficient tokens for VU ${__VU}: only ${tokens.length} available. ` +
+      `Run: COUNT=${__VU} node loadtest/prepare-tokens.js`,
+    );
+  }
+  const token = tokens[__VU - 1];
 
   const res = ws.connect(
     WS_URL,
@@ -124,14 +133,10 @@ function handleFrame(socket, frame, connectStartAt) {
       socket.send(STOMP.subscribe(`sub-chat-${__VU}`, '/topic/chat/village'));
       socket.send(STOMP.subscribe(`sub-pos-${__VU}`, '/topic/village/positions'));
 
-      // position 루프 (±20% jitter)
-      socket.setInterval(() => {
-        const x = Math.random() * MAP_MAX_X;
-        const y = Math.random() * MAP_MAX_Y;
-        socket.send(STOMP.send('/app/village/position', { x, y }));
-        mPosSent.add(1);
-      }, jitter(POSITION_INTERVAL_MS, 0.2));
-
+      // position 루프 — 매 전송마다 jitter 재샘플링.
+      // setInterval 은 등록 시점에 jitter 를 1회만 계산해서 VU 별로 고정 cadence 가 됨.
+      // 재귀 setTimeout 으로 매번 새 jitter 값을 뽑아 트래픽 분산 효과 확보.
+      schedulePosition(socket);
       scheduleChat(socket);
       break;
     }
@@ -149,6 +154,16 @@ function handleFrame(socket, frame, connectStartAt) {
     default:
       break;
   }
+}
+
+function schedulePosition(socket) {
+  socket.setTimeout(() => {
+    const x = Math.random() * MAP_MAX_X;
+    const y = Math.random() * MAP_MAX_Y;
+    socket.send(STOMP.send('/app/village/position', { x, y }));
+    mPosSent.add(1);
+    schedulePosition(socket);
+  }, jitter(POSITION_INTERVAL_MS, 0.2));
 }
 
 function scheduleChat(socket) {

--- a/loadtest/village-mixed.js
+++ b/loadtest/village-mixed.js
@@ -1,0 +1,167 @@
+// 마을 혼합 부하 시나리오 — position + chat
+//
+// 실행 예:
+//   # 스모크 (VU 1, 30초)
+//   BASE_URL=https://ghworld.co WS_URL=wss://ghworld.co/ws/websocket \
+//     k6 run --vus 1 --duration 30s loadtest/village-mixed.js
+//
+//   # 본부하 (ramping 0→50→500→1000→0)
+//   BASE_URL=... WS_URL=... k6 run \
+//     --stage 1m:50 --stage 3m:500 --stage 5m:1000 --stage 2m:0 \
+//     --summary-export=loadtest/summary.json \
+//     loadtest/village-mixed.js
+//
+// 각 VU:
+//   1) CONNECT (Authorization 헤더로 JWT)
+//   2) SUBSCRIBE /topic/chat/village, /topic/village/positions
+//   3) position SEND 매 500ms (jitter)
+//   4) chat SEND 15~30s 랜덤 간격
+//   5) 세션 종료 → DISCONNECT
+
+import ws from 'k6/ws';
+import { check } from 'k6';
+import { Counter, Trend } from 'k6/metrics';
+import { SharedArray } from 'k6/data';
+import { STOMP, parseStompFrame } from './lib/stomp.js';
+
+const BASE_URL = __ENV.BASE_URL || 'https://ghworld.co';
+const WS_URL = __ENV.WS_URL || 'wss://ghworld.co/ws/websocket';
+
+// k6 런타임에 URL 글로벌이 없으므로 수동 파싱 (https://host[:port]/path → host, origin).
+function parseOrigin(url) {
+  const m = url.match(/^(https?):\/\/([^/]+)/);
+  if (!m) throw new Error(`invalid BASE_URL: ${url}`);
+  return { host: m[2], origin: `${m[1]}://${m[2]}` };
+}
+const { host: HOST, origin: ORIGIN } = parseOrigin(BASE_URL);
+
+const SESSION_MS = parseInt(__ENV.SESSION_MS || '30000', 10);
+const POSITION_INTERVAL_MS = parseInt(__ENV.POSITION_INTERVAL_MS || '500', 10);
+const CHAT_MIN_MS = parseInt(__ENV.CHAT_MIN_MS || '15000', 10);
+const CHAT_MAX_MS = parseInt(__ENV.CHAT_MAX_MS || '30000', 10);
+const MAP_MAX_X = 2400;
+const MAP_MAX_Y = 1600;
+
+const tokens = new SharedArray('tokens', () => JSON.parse(open('./tokens.json')));
+
+const mConnected = new Counter('stomp_connected');
+const mPosSent = new Counter('position_sent');
+const mPosRecv = new Counter('position_received');
+const mChatSent = new Counter('chat_sent');
+const mChatRecv = new Counter('chat_received');
+const mStompErr = new Counter('stomp_errors');
+const mConnectLatency = new Trend('stomp_connect_latency', true);
+
+// CLI 인자(--vus, --duration, --stage)로 부하 프로파일 주입.
+// scenarios 블록은 정의하지 않아서 CLI 플래그가 그대로 먹는다.
+export const options = {
+  thresholds: {
+    stomp_connect_latency: ['p(95)<3000'],
+    stomp_errors: ['count<10'],
+  },
+};
+
+export default function () {
+  if (tokens.length === 0) {
+    throw new Error('tokens.json empty — run prepare-tokens.js first');
+  }
+  const token = tokens[(__VU - 1) % tokens.length];
+
+  const res = ws.connect(
+    WS_URL,
+    { headers: { Origin: ORIGIN } },
+    (socket) => {
+      let buffer = '';
+      let connectStartAt = 0;
+
+      socket.on('open', () => {
+        connectStartAt = Date.now();
+        socket.send(STOMP.connect(token, HOST));
+      });
+
+      socket.on('message', (raw) => {
+        buffer += raw;
+        // STOMP 프레임은 \x00로 종료. 한 ws frame에 복수 STOMP 프레임이 올 수 있어 버퍼로 분리.
+        let idx;
+        while ((idx = buffer.indexOf('\x00')) !== -1) {
+          const frameText = buffer.slice(0, idx + 1);
+          buffer = buffer.slice(idx + 1).replace(/^\n+/, ''); // 프레임 사이 heartbeat newline 제거
+          handleFrame(socket, parseStompFrame(frameText), connectStartAt);
+        }
+      });
+
+      socket.on('error', (e) => {
+        console.log(`[VU${__VU}] socket error: ${e.error ? e.error() : e}`);
+        mStompErr.add(1);
+      });
+
+      socket.setTimeout(() => {
+        try { socket.send(STOMP.disconnect()); } catch (_) { /* noop */ }
+        socket.close();
+      }, SESSION_MS);
+    },
+  );
+
+  check(res, {
+    'handshake is 101': (r) => r && r.status === 101,
+  });
+
+  if (!res || res.status !== 101) {
+    console.log(`[VU${__VU}] handshake failed: status=${res && res.status}`);
+    mStompErr.add(1);
+  }
+}
+
+function handleFrame(socket, frame, connectStartAt) {
+  switch (frame.command) {
+    case 'CONNECTED': {
+      mConnected.add(1);
+      if (connectStartAt > 0) {
+        mConnectLatency.add(Date.now() - connectStartAt);
+      }
+
+      socket.send(STOMP.subscribe(`sub-chat-${__VU}`, '/topic/chat/village'));
+      socket.send(STOMP.subscribe(`sub-pos-${__VU}`, '/topic/village/positions'));
+
+      // position 루프 (±20% jitter)
+      socket.setInterval(() => {
+        const x = Math.random() * MAP_MAX_X;
+        const y = Math.random() * MAP_MAX_Y;
+        socket.send(STOMP.send('/app/village/position', { x, y }));
+        mPosSent.add(1);
+      }, jitter(POSITION_INTERVAL_MS, 0.2));
+
+      scheduleChat(socket);
+      break;
+    }
+    case 'MESSAGE': {
+      const dest = frame.headers.destination || '';
+      if (dest.startsWith('/topic/village/positions')) mPosRecv.add(1);
+      else if (dest.startsWith('/topic/chat/village')) mChatRecv.add(1);
+      break;
+    }
+    case 'ERROR': {
+      mStompErr.add(1);
+      console.log(`[VU${__VU}] STOMP ERROR: ${frame.body}`);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function scheduleChat(socket) {
+  const delay = CHAT_MIN_MS + Math.random() * (CHAT_MAX_MS - CHAT_MIN_MS);
+  socket.setTimeout(() => {
+    socket.send(STOMP.send('/app/chat/village', {
+      body: `VU${__VU} ${Date.now()}`,
+    }));
+    mChatSent.add(1);
+    scheduleChat(socket);
+  }, delay);
+}
+
+function jitter(base, ratio) {
+  const delta = base * ratio * (Math.random() * 2 - 1);
+  return Math.max(50, Math.floor(base + delta));
+}

--- a/loadtest/village-mixed.js
+++ b/loadtest/village-mixed.js
@@ -85,7 +85,8 @@ export default function () {
         let idx;
         while ((idx = buffer.indexOf('\x00')) !== -1) {
           const frameText = buffer.slice(0, idx + 1);
-          buffer = buffer.slice(idx + 1).replace(/^\n+/, ''); // 프레임 사이 heartbeat newline 제거
+          // 프레임 사이 heartbeat (\n 또는 \r\n 반복) 제거. STOMP 1.2는 CRLF 도 허용.
+          buffer = buffer.slice(idx + 1).replace(/^(?:\r?\n)+/, '');
           handleFrame(socket, parseStompFrame(frameText), connectStartAt);
         }
       });

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -164,6 +164,29 @@ EC2 콘솔 → gohyang-monitor → Stop instance
 
 재개하려면 Start instance. **Terminate는 하지 말 것** — EBS 볼륨까지 삭제됨.
 
+## k6 메트릭 수집 (Remote Write)
+
+Prometheus가 `--web.enable-remote-write-receiver` 플래그로 기동되므로 외부 툴(k6 등)이 `http://<prometheus>:9090/api/v1/write` 엔드포인트에 메트릭 PUSH 가능.
+
+**사용 시나리오**: 부하 테스트 중 k6의 `stomp_connect_latency`, `position_sent` 등 클라이언트 메트릭을 Grafana에 시각화.
+
+**접근 방법**: Prometheus는 127.0.0.1 바인딩 유지. 외부 k6는 SSM 포트포워딩으로 9090 접근.
+
+```bash
+aws ssm start-session \
+  --target <monitor-ec2-instance-id> \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters "portNumber=9090,localPortNumber=9090" \
+  --region ap-northeast-2
+```
+
+**Grafana에서 시각화**:
+
+- `+` → Import → Dashboard ID `19665` (k6 공식) → Prometheus 데이터 소스 선택
+- k6_* 라벨 달린 메트릭 자동 매핑
+
+상세 실행 커맨드: `loadtest/README.md` 5번 섹션.
+
 ## IP 변경 대응 (운영 EC2 Private IP가 바뀌었을 때)
 
 ```bash

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -39,6 +39,10 @@ services:
       - '--storage.tsdb.retention.time=7d'
       # 런타임 설정 리로드 허용 (prometheus.yml 수정 후 curl -X POST ...:9090/-/reload)
       - '--web.enable-lifecycle'
+      # Remote Write receiver — k6 등 외부 툴이 메트릭을 /api/v1/write 로 PUSH 가능.
+      # 부하 테스트 중 k6의 stomp_connect_latency 등을 Grafana에 그리기 위해 필요.
+      # 운영 EC2 접근은 여전히 127.0.0.1 바인딩 + SSM port-forward 로만 허용되므로 공격 벡터 아님.
+      - '--web.enable-remote-write-receiver'
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:9090/-/healthy"]
       interval: 10s

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -35,8 +35,11 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
-      # 7일 retention — 부하 테스트 데이터만 보관, 장기 저장 불필요
+      # 7일 시간 보관 — 부하 테스트 데이터만, 장기 저장 불필요
       - '--storage.tsdb.retention.time=7d'
+      # 용량 상한 — remote-write 로 k6 시계열 급증 시 디스크 고갈 방지.
+      # time·size 둘 중 먼저 닿는 쪽에 compaction 발동. env 로 오버라이드 가능.
+      - '--storage.tsdb.retention.size=${PROMETHEUS_RETENTION_SIZE:-10GB}'
       # 런타임 설정 리로드 허용 (prometheus.yml 수정 후 curl -X POST ...:9090/-/reload)
       - '--web.enable-lifecycle'
       # Remote Write receiver — k6 등 외부 툴이 메트릭을 /api/v1/write 로 PUSH 가능.


### PR DESCRIPTION
## Summary

부하 테스트 중 관찰된 두 가지 모니터링 한계 해결.

## 변경 사항

### ① Backend — Micrometer histogram bucket 노출
- `application.yml`에 `management.metrics.distribution.percentiles-histogram` 추가
- `http.server.requests`, `jvm.gc.pause` Timer에 대해 bucket + client-side percentile 동시 노출
- **효과**: Grafana에서 `histogram_quantile(0.95, rate(..._bucket[1m]))` 쿼리가 실제 p95/p99 시계열 반환 (기존엔 No Data → `_max` fallback만 가능)

### ② Monitoring — Prometheus Remote Write 활성화
- `monitoring/docker-compose.yml` 에 `--web.enable-remote-write-receiver` flag 추가
- **보안 유지**: 여전히 127.0.0.1 바인딩 → 외부 k6는 SSM port-forward 로만 접근 가능 (공격 벡터 없음)
- **효과**: k6의 `stomp_connect_latency` 등 클라이언트 메트릭을 Prometheus에 PUSH → Grafana 공식 대시보드 ID `19665` 로 시각화 가능

### ③ 문서 갱신
- `monitoring/README.md` — Remote Write 사용 시나리오 + SSM port-forward 커맨드
- `loadtest/README.md` — k6 실행 시 `K6_PROMETHEUS_RW_SERVER_URL` + `--out experimental-prometheus-rw` 절차

## 적용 절차 (배포 후)

### Backend (CD 자동)
- 이 PR merge → CD 자동 재배포 → histogram bucket 즉시 노출 시작
- Grafana `Load Test Live` 대시보드의 기존 `histogram_quantile(...)` 쿼리가 바로 작동

### Monitoring (monitor EC2에서 수동)
```bash
ssh monitor  # 또는 SSM
cd ~/ChatAppProject/monitoring
git pull origin main
docker compose up -d prometheus  # --web.enable-remote-write-receiver 적용됨
```

### k6 (로컬에서)
```bash
# SSM port-forward (별도 터미널 유지)
aws ssm start-session --target <monitor-ec2> \
  --document-name AWS-StartPortForwardingSession \
  --parameters "portNumber=9090,localPortNumber=9090" --region ap-northeast-2

# k6 실행 (다른 터미널)
K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write \
  k6 run --out experimental-prometheus-rw ...
```

### Grafana
- `+` → Import → Dashboard ID `19665` → Data source: Prometheus

## Test plan

- [x] application.yml 문법 검증 (Spring Boot 표준 구조)
- [x] monitoring/docker-compose.yml command 배열 유효 (Prometheus 2.55 지원)
- [ ] Merge 후 Grafana에서 `histogram_quantile` 쿼리 실제 값 반환 확인
- [ ] Prometheus `/api/v1/write` POST 가능 확인 (k6 실행 후 `k6_*` 메트릭 조회)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 부하 테스트 및 모니터링 사용법(토큰 준비, 실행/요약 수집, Prometheus Remote Write 및 Grafana 대시보드 import) 추가

* **New Features**
  * k6 기반 부하 테스트 스크립트, 토큰 준비 CLI 및 STOMP 헬퍼 유틸리티 추가

* **Configuration**
  * HTTP 서버 요청 및 JVM GC pause에 대한 메트릭 히스토그램·백분위수(0.5/0.95/0.99) 노출 설정 추가
  * Prometheus 원격 쓰기 수신기 활성화 및 보존 크기 옵션 추가

* **Chores**
  * 로컬 부하테스트 산출물(.json/.log 등)과 도구 캐시 경로를 .gitignore에 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->