### PR TITLE
docs: PR #29 CodeRabbit 3차 리뷰 반영 (머지 후 후속)

### DIFF
--- a/docs/handover/track-ghost-session.md
+++ b/docs/handover/track-ghost-session.md
@@ -50,10 +50,9 @@ Step 1 시작 전. 본 트랙을 이어받을 다음 세션 절차:
 
 ## 5. 다음 세션 착수 전 확인 사항
 
-- 워크트리 cwd 가 `<repo-root>/ChatAppProject-ui` 인지 확인 (`git worktree list`)
-- 브랜치 `fix/ghost-session` 인지 확인
-- 사용자 docs 정합성 머지 완료 여부 (확인 후 main pull → rebase)
-- `ws-redis` Step 2 worktree 가 `PositionDisconnectListener` / SessionRegistry 영역을 동시 수정 중인지 확인 → 동시 수정이면 정책 결정 합의 먼저
+> 워크트리/브랜치/main 정합성/`ws-redis` 트랙 정책 합의 등 절차 항목은 §3 의 1~4 와 동일 — 본 트랙의 단일 진실원은 §3. 갱신은 §3 한 곳만 수정한다.
+
+- 본 트랙 진입 전 절차: §3 의 1~4 항목 그대로 수행
 - 학습 노트 번호: `RESERVED.md` 의 `ghost-session` 예약 (54~58) 사용
 
 ## 6. 보류 메모

--- a/docs/knowledge/ai-native/handover-collision-management.md
+++ b/docs/knowledge/ai-native/handover-collision-management.md
@@ -197,7 +197,7 @@ project/
 
 | 개선 항목 | 변경 내용 |
 |---------|---------|
-| **세션 종류 판별** | hook 시작에서 `git-common-dir` vs `show-toplevel` 비교, 메인/워크트리 분기 |
+| **세션 종류 판별** | hook 시작에서 `git-dir` vs `git-common-dir` 비교 (정규화 후), 메인/워크트리 분기 |
 | **갱신 대상 파일 라우팅** | 메인 → `docs/handover.md`, 워크트리 → `docs/handover/track-{branchSlug}.md` |
 | **트랙 ID 추출** | `git symbolic-ref --short HEAD` → slugify(`feature/ws-redis` → `ws-redis`) |
 | **hook 위치 안전화** | `.claude/settings.json` 의존 줄이고 `$CLAUDE_PROJECT_DIR/scripts/`에서 호출되도록 (Issue #46808 회피) |


### PR DESCRIPTION
## Summary

PR #29 머지(2026-04-26) 이후 추가로 올라온 CodeRabbit 3차 리뷰 코멘트 3건을 별도 PR로 분리하여 반영.

원 PR이 이미 squash-merge 되어 같은 브랜치에 push해도 main에 반영 불가 → 새 브랜치 분기 후 review-fix 커밋만 cherry-pick.

## 반영 내역

- **#1 (Major, id 3143609342)**: 본문 §3.2의 메인/워크트리 세션 판별 로직은 이미 직전 PR의 `f379aff` 커밋에서 `git-dir == git-common-dir`로 정정됨 → 추가 수정 불필요로 확인.
- **#2 (Major, id 3143641788)**: §3.3 "권장 개선" 표의 "세션 종류 판별" 행이 `git-common-dir vs show-toplevel`로 남아있어 본문과 모순 → `git-dir vs git-common-dir`(정규화 후)로 통일.
- **#3 (Trivial, id 3143641785)**: `track-ghost-session.md` §3과 §5의 체크리스트 4항목 중복 → §5를 §3 참조로 압축, 트랙 고유 정보(학습 노트 번호)만 §5에 유지.

변경: 2 files, +4 / -5

## Test plan

- [x] 본문(§3.2)과 표(§3.3)의 세션 판별 기준 일관성 확인
- [x] track-ghost-session.md §3·§5 중복 제거 후 트랙 시작 절차에 누락 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 세션 초기화 단계 문서를 재정리하여 단일 참조 지점으로 통합했습니다.
  * Git 워크트리 감지 로직에 대한 안내를 업데이트하여 더 정확한 방법을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->