### PR TITLE
fix(ui): 유령 캐릭터 — 게스트 토큰 재발급 시 자기인식 stale 해소 (#28)

### DIFF
--- a/backend/src/main/java/com/maeum/gohyang/identity/adapter/in/security/JwtProvider.java
+++ b/backend/src/main/java/com/maeum/gohyang/identity/adapter/in/security/JwtProvider.java
@@ -32,6 +32,9 @@ public class JwtProvider implements IssueTokenPort, ParseTokenPort {
     @Value("${jwt.access-token-expiry-ms}")
     private long accessTokenExpiryMs;
 
+    @Value("${jwt.guest-token-expiry-ms}")
+    private long guestTokenExpiryMs;
+
     private SecretKey secretKey;
 
     @PostConstruct
@@ -46,12 +49,12 @@ public class JwtProvider implements IssueTokenPort, ParseTokenPort {
 
     @Override
     public String issueMemberToken(Long userId) {
-        return buildToken(String.valueOf(userId), UserType.MEMBER);
+        return buildToken(String.valueOf(userId), UserType.MEMBER, accessTokenExpiryMs);
     }
 
     @Override
     public String issueGuestToken() {
-        return buildToken("guest-" + UUID.randomUUID(), UserType.GUEST);
+        return buildToken("guest-" + UUID.randomUUID(), UserType.GUEST, guestTokenExpiryMs);
     }
 
     /**
@@ -79,13 +82,13 @@ public class JwtProvider implements IssueTokenPort, ParseTokenPort {
         }
     }
 
-    private String buildToken(String subject, UserType role) {
+    private String buildToken(String subject, UserType role, long expiryMs) {
         Date now = new Date();
         return Jwts.builder()
                 .subject(subject)
                 .claim("role", role.name())
                 .issuedAt(now)
-                .expiration(new Date(now.getTime() + accessTokenExpiryMs))
+                .expiration(new Date(now.getTime() + expiryMs))
                 .signWith(secretKey)
                 .compact();
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -55,6 +55,9 @@ server:
 jwt:
   secret: ${JWT_SECRET:local-dev-only-secret-key-must-be-at-least-256-bits-long!!}
   access-token-expiry-ms: 3600000
+  # 게스트는 권한이 거의 없고(마을 위치/공개 채팅), 토큰이 곧 displayId 라 만료 시 sessionId 가 바뀐다.
+  # 짧은 만료는 자기인식 stale + 유령 캐릭터를 유발하므로 멤버보다 길게 둔다 (#28 fix).
+  guest-token-expiry-ms: 86400000
   refresh-token-expiry-ms: 604800000
 
 # Actuator endpoint는 secure-by-default (기본값 'health' 하나만 노출).

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -27,6 +27,7 @@ spring:
 jwt:
   secret: test-only-secret-key-must-be-at-least-256-bits-long-value!!
   access-token-expiry-ms: 3600000
+  guest-token-expiry-ms: 86400000
   refresh-token-expiry-ms: 604800000
 
 management:

--- a/docs/handover/track-ghost-session.md
+++ b/docs/handover/track-ghost-session.md
@@ -21,21 +21,23 @@
 
 | Step | 작업 | 상태 |
 |------|------|------|
-| 1 | 재현 시나리오 정리 + 기존 disconnect/cleanup 경로 코드 워크스루 (`learning/54` — presence cleanup 진단) | 대기 |
-| 2 | 동시 세션 정책 결정 (대체 / 거부 / 병행) — 🔒 사용자 승인 게이트 (`learning/55` — 정책 트레이드오프) | 대기 |
-| 3 | 백엔드 수정 — disconnect 처리 강화 + 결정된 다중 세션 정책 적용 | 대기 |
-| 4 | 프론트엔드 정리 — 유령 잔존 시점에 클라이언트 측 stale 식별 가능한지 검증 | 대기 |
-| 5 | 통합 검증 (멀티 클라이언트 시나리오) + 운영 배포 | 대기 |
+| 1 | 재현 시나리오 정리 + 기존 disconnect/cleanup 경로 코드 워크스루 (`learning/54` — presence cleanup 진단) | ✅ 완료 |
+| 2 | fix 방향 합의 (토큰 재사용·myDisplayId 갱신·beforeunload graceful disconnect) — 🔒 사용자 승인 게이트 | 진행 중 |
+| 3 | 프론트엔드 fix 구현 — `useStomp.onError` 토큰 재사용 + `VillageScene.myDisplayId` 갱신 | 대기 |
+| 4 | 보조 — `beforeunload` graceful disconnect 추가 (탭 종료 시 LEAVE 빠르게) | 대기 |
+| 5 | 통합 검증 (멀티 탭 시나리오 + 콜드 스타트 시뮬레이션) + 운영 배포 | 대기 |
+
+> **범위 외**: 동일 `userId` 다중 세션 정책 (대체/거부/병행) — #28 진단 결과 본 트랙의 직접 원인이 아님이 확정 (`learning/54` 참조). 별도 이슈로 분리, 향후 멀티 디바이스/멀티 탭 시나리오가 실제 문제로 보고되면 그때 트랙 시작.
 
 ## 3. 현재 단계 상세
 
-Step 1 시작 전. 본 트랙을 이어받을 다음 세션 절차:
+Step 1 완료. Step 2 (fix 방향 합의 게이트) 진행 중. 본 트랙을 이어받을 다음 세션 절차:
 
 1. 워크트리 cwd 확인 (`<repo-root>/ChatAppProject-ui` — `git worktree list` 로 실제 경로 검증)
 2. 브랜치 `fix/ghost-session` 인지 확인
-3. 사용자가 main 정합성 docs PR 머지 완료한 상태에서 시작 → main pull → rebase
-4. `ws-redis` 트랙 진행 상황 INDEX 확인 — Step 2 백엔드 SessionRegistry 영역과 본 트랙 정책 결정이 겹친다. **두 트랙 간 정책 합의 먼저.**
-5. `learning/54` 작성 (presence cleanup 경로 진단)
+3. main 정합성 docs PR 머지 완료 — main pull 완료 (2026-04-27)
+4. `learning/54` 진단 결과 확인 — 진짜 원인은 게스트 토큰 재발급 + `myDisplayId` stale (백엔드 cleanup 경로 정상)
+5. Step 2 fix 1·2·3 합의 후 Step 3 구현 계획서 → 구현
 
 ## 4. 충돌 위험 파일
 
@@ -43,17 +45,18 @@ Step 1 시작 전. 본 트랙을 이어받을 다음 세션 절차:
 
 | 파일 (축약/풀) | 분류 | 메모 |
 |---------------|------|------|
-| `village/adapter/in/websocket/PositionDisconnectListener.java`<br/>(`backend/src/main/java/com/maeum/gohyang/village/adapter/in/websocket/PositionDisconnectListener.java`) | 트랙 잠재 | `ws-redis` Step 2/3 도 이 영역을 건드릴 가능성. 다중 세션 정책이 어느 트랙에서 들어갈지 사전 합의 필요 |
-| `communication/adapter/in/websocket/**`<br/>(`backend/src/main/java/com/maeum/gohyang/communication/adapter/in/websocket/**`) | 트랙 잠재 | `ws-redis` Step 2~6 가 STOMP → raw WS + Redis Pub/Sub 교체 중. 본 트랙은 가급적 `village` 영역만 만지고 `communication` 은 회피 |
-| `frontend/src/components/village/**` | 트랙 전용 | UI 트랙이 이전에도 만진 영역. 다른 트랙 동시 수정 가능성 낮음 |
-| `frontend/src/lib/websocket/**` | 트랙 잠재 | `ws-redis` Step 6 (STOMP 클라이언트 제거) 와 동시 수정 시 충돌. 본 트랙은 client 코드 수정 회피 권장 |
+| `frontend/src/lib/websocket/useStomp.ts` | 트랙 잠재 | **본 트랙 핵심 수정 영역** (Step 3). `ws-redis` Step 6 (STOMP 클라이언트 제거) 와 동시 수정 시 충돌 — 본 트랙이 먼저 머지되거나 ws-redis 가 STOMP 제거 시 본 fix 가 자연스레 사라지도록 협의. |
+| `frontend/src/game/scenes/VillageScene.ts` | 트랙 전용 | **본 트랙 핵심 수정 영역** (Step 3). `myDisplayId` 갱신 로직 추가. UI 트랙 종료됨 — 충돌 가능성 낮음. |
+| `frontend/src/lib/websocket/stompClient.ts` | 트랙 잠재 | Step 4 graceful disconnect 추가 시 만질 가능성. `ws-redis` Step 6 와 동일 협의 영역. |
+| `village/adapter/in/websocket/PositionDisconnectListener.java`<br/>(`backend/src/main/java/com/maeum/gohyang/village/adapter/in/websocket/PositionDisconnectListener.java`) | 트랙 잠재 | 본 트랙은 백엔드 수정 안 함 (진단 결과 정상 동작). 참고용. |
+| `communication/adapter/in/websocket/**` | 회피 | `ws-redis` Step 2~6 가 교체 중. 본 트랙 건드리지 않음. |
 
 ## 5. 다음 세션 착수 전 확인 사항
 
 > 워크트리/브랜치/main 정합성/`ws-redis` 트랙 정책 합의 등 절차 항목은 §3 의 1~4 와 동일 — 본 트랙의 단일 진실원은 §3. 갱신은 §3 한 곳만 수정한다.
 
-- 본 트랙 진입 전 절차: §3 의 1~4 항목 그대로 수행
-- 학습 노트 번호: `RESERVED.md` 의 `ghost-session` 예약 (54~58) 사용
+- 본 트랙 진입 전 절차: §3 의 1~5 항목 그대로 수행
+- 학습 노트 번호: `RESERVED.md` 의 `ghost-session` 예약 (54 사용 완료, 56 회고용 예비). 55·57·58 은 반환됨 — 다중 세션 정책 별도 이슈에서 재예약 가능.
 
 ## 6. 보류 메모
 

--- a/docs/learning/54-presence-cleanup-ghost-character-diagnosis.md
+++ b/docs/learning/54-presence-cleanup-ghost-character-diagnosis.md
@@ -1,0 +1,455 @@
+# 54. presence cleanup — "본인을 따라다니는 유령 캐릭터" 진단기
+
+> 작성 시점: 2026-04-27
+> 트랙: `ghost-session` (첫 노트, Step 1 산출물)
+> 맥락: 운영 환경 `ghworld.co` 에서 보고된 issue #28 — "다른 클라이언트 화면에 본인을 따라다니는 손님 캐릭터가 잔존". Step 1 = 진단, Step 2 = 정책 합의 게이트의 인풋
+> 관련 파일:
+> - `frontend/src/lib/websocket/useStomp.ts:67-79, 133-144`
+> - `frontend/src/game/scenes/VillageScene.ts:104-109, 449-466, 485-502, 543-555`
+> - `backend/src/main/java/com/maeum/gohyang/global/security/AuthenticatedUser.java:41-46`
+> - `backend/src/main/java/com/maeum/gohyang/village/adapter/in/websocket/PositionHandler.java`
+> - `backend/src/main/java/com/maeum/gohyang/village/adapter/in/websocket/PositionDisconnectListener.java`
+
+---
+
+## 0. 한 줄 요약
+
+**유령의 95% 는 백엔드 presence cleanup 의 문제가 아니다. 게스트 토큰이 onError 마다 재발급되면서 클라이언트의 "내가 누구냐(myDisplayId)" 가 stale 되고, 자기 자신을 다른 사람으로 오인해 자기 화면에 추가하는 프론트엔드 버그다.**
+
+issue #28 본문은 백엔드 `PositionDisconnectListener` 의 disconnect 처리 누락·`sweepStalePlayers` 와 STOMP DISCONNECT 의 정책 미정의·동일 userId 다중 connection 정책 부재를 의심했다. 코드 워크스루 결과 진짜 원인은 다른 곳이었다 — 토큰 재발급 → `sessionId` 변경 → `displayId()` 변경 → 자기 무시 비교 실패. "본인을 따라다닌다" 는 표현은 이 메커니즘에서만 자연스럽게 설명된다.
+
+이 노트는 진단의 최종 결과를 정리해서, Step 2 (정책 합의 게이트) 에서 "그래서 무엇을 고치자" 를 논의할 때 출발점이 되도록 만든 것이다. **fix 는 Step 2 승인 후 시작한다 — 본 노트는 진단 + 인풋용이지 실행 계획이 아니다.**
+
+---
+
+## 1. 증상 — issue #28 이 보고한 그림
+
+```text
+운영 환경 (ghworld.co), 다중 사용자 입장 직후
+
+A 유저 화면:
+  - 자기 캐릭터(움직임) + "손님 캐릭터" 1명이 본인을 그대로 따라다님
+  - 자기가 동/서/남/북 어디로 가든 손님이 같은 속도로 따라옴
+
+B 유저 화면 (동시 접속):
+  - A 의 "이전" 캐릭터가 아무 데도 안 가고 정지 상태로 남아 있음
+  - A 의 "현재" 캐릭터는 옆에서 정상 동작
+  - 30초쯤 지나면 정지된 캐릭터가 사라짐
+```
+
+issue 본문이 강조한 부분: **"본인을 따라다니는"** 이라는 표현. 이게 핵심 단서다. 단순한 "끊긴 캐릭터가 안 사라지는" 문제라면 정지 상태로 남아 있어야 한다. 따라다닌다 = 누군가 좌표 broadcast 를 계속 보내고 있다는 뜻.
+
+### 1.1 issue 본문이 의심한 원인
+
+| # | 의심 지점 | 의심 근거 |
+|---|---|---|
+| 1 | `PositionDisconnectListener` 의 disconnect 처리 누락/지연 | LEAVE broadcast 가 안 가서 캐릭터가 안 사라진다는 가설 |
+| 2 | `sweepStalePlayers` (30초 stale 청소) ↔ STOMP DISCONNECT 두 경로의 정책 미정의 | "둘 중 어느 쪽이 진실 소스인가" 가 불명확 |
+| 3 | 동일 userId 다중 connection 정책 부재 | 같은 유저의 여러 세션이 별개 player 로 인식되는 시나리오 |
+
+세 의심 모두 **백엔드 presence cleanup** 영역. 즉 보고자는 "서버가 누군가 떠난 걸 모르거나, 늦게 알거나, 같은 사람을 두 명으로 본다" 라고 추측했다.
+
+### 1.2 결과 — 셋 다 진짜 원인이 아니다
+
+코드 워크스루 결과 셋 다 보조 원인이거나 무관:
+
+- 의심 1: `PositionDisconnectListener` 자체는 정상. 이벤트가 늦게 도착할 뿐.
+- 의심 2: `sweepStalePlayers` 는 프론트엔드 방어선이고 30초 후 동작함 — 보고된 증상의 시간 척도(즉시·지속)와 안 맞음.
+- 의심 3: 동일 userId 다중 connection 은 다른 트랙(`ws-redis`) 의 영역. 본 증상의 직접 원인은 아니며, **같은 유저가 다른 displayId 로 보이는 메커니즘이 따로 있다.**
+
+진짜 원인은 다음 섹션.
+
+---
+
+## 2. 진짜 원인 — 프론트엔드 자기인식의 stale
+
+### 2.1 한 줄
+
+`VillageScene.myDisplayId` 가 씬 create 시점에 한 번만 결정되는데, 그 사이에 STOMP `onError` → 토큰 삭제 → 토큰 재발급이 일어나면 새 토큰의 `displayId` 와 어긋난다. 그 다음부터 자기 broadcast 를 자기가 받아도 자기 무시 비교가 실패해서 "다른 사람" 으로 처리된다.
+
+### 2.2 코드로 추적
+
+#### (1) `myDisplayId` 결정 — 1회만
+
+`frontend/src/game/scenes/VillageScene.ts:449-466`
+
+```ts
+private resolveMyDisplayId(): string {
+  // accessToken 의 payload 를 디코드해서 sub/sessionId 로 displayId 결정
+  // 게스트면 "guest-AAA" 같은 sessionId 그대로
+  // ...
+}
+```
+
+이 함수가 호출되는 위치는 `create()` 안 한 곳뿐 (`VillageScene.ts:104-109` 근처). 즉 **씬이 생성된 시점의 토큰 기준으로 한 번만 myDisplayId 가 박힌다.** 토큰이 나중에 바뀌어도 이 값은 갱신되지 않는다.
+
+#### (2) STOMP onError → 토큰 삭제
+
+`frontend/src/lib/websocket/useStomp.ts:133-144`
+
+```ts
+onWebSocketError: (event) => {
+  // ...
+  localStorage.removeItem('accessToken');
+  setTimeout(() => connect(), 3000);
+},
+```
+
+콜드 스타트, 네트워크 흔들림, 백엔드 일시적 hiccup 어느 것이든 `onError` 가 트리거되면 토큰을 지운다. 의도는 "토큰이 만료됐을 수도 있으니 새로 받자" 였을 것으로 [추정]. 하지만 트리거 조건이 만료 외에도 너무 많다.
+
+#### (3) 토큰 재발급 → 새 sessionId
+
+`frontend/src/lib/websocket/useStomp.ts:67-79`
+
+```ts
+async function ensureAccessToken() {
+  let token = localStorage.getItem('accessToken');
+  if (!token) {
+    const res = await fetch('/api/v1/auth/guest', { method: 'POST' });
+    token = (await res.json()).accessToken;
+    localStorage.setItem('accessToken', token);
+  }
+  return token;
+}
+```
+
+토큰이 없으면 `/api/v1/auth/guest` 를 호출. 백엔드는 새 게스트를 발급하므로 **sessionId 가 다른 새 토큰**을 준다.
+
+#### (4) 게스트 displayId = sessionId
+
+`backend/src/main/java/com/maeum/gohyang/global/security/AuthenticatedUser.java:41-46`
+
+```java
+public String displayId() {
+    if (userId != null) {
+        return MEMBER_PREFIX + userId;            // MEMBER: user-{userId} (영속)
+    }
+    return sessionId != null ? sessionId : GUEST_FALLBACK;
+    // GUEST: sessionId 그대로 (토큰마다 다름)
+}
+```
+
+핵심 코드. **회원은 userId 가 영속 식별자라 토큰을 새로 받아도 displayId 가 같다. 게스트는 영속 식별자가 없어서 sessionId 가 displayId 가 되고, 토큰이 새로 발급되면 displayId 도 같이 바뀐다.**
+
+#### (5) 자기 broadcast 가 자기에게 도달
+
+새 토큰으로 재연결 후 `sendPosition(x, y)` 가 호출되면 서버는 새 토큰의 `displayId() = guest-BBB` 로 broadcast. 자기 자신도 이 broadcast 를 받는다.
+
+#### (6) 자기 무시 비교 실패
+
+`frontend/src/game/scenes/VillageScene.ts:485-502`
+
+```ts
+private handleRemotePosition(pos: { id: string; x: number; y: number }) {
+  if (pos.id === this.myDisplayId) return;   // ← 자기 무시
+  // 그 외엔 addOtherPlayer / updateOtherPlayer
+}
+```
+
+비교 결과: `'guest-BBB' === 'guest-AAA'` → false → 자기 무시 실패 → `addOtherPlayer()` 가 호출되고, 자기 좌표가 새 캐릭터로 추가된다.
+
+#### (7) 매 프레임 자기 좌표가 broadcast 되므로 따라다님
+
+플레이어가 움직이면 `sendPosition` 이 매 프레임(또는 throttle 간격) 호출. 모든 broadcast 가 `guest-BBB` 로 들어오고, 자기 무시는 계속 실패. 결과적으로 그 "손님" 캐릭터의 `targetX/targetY` 가 본인 좌표로 매번 갱신 → **본인을 그대로 따라다니는 유령 완성**.
+
+### 2.3 다른 클라이언트 화면에서는?
+
+같은 메커니즘의 다른 측면이 보인다:
+
+- 이전 세션의 `guest-AAA` 캐릭터가 잠깐 남아 있다가 30초 후 `sweepStalePlayers` 로 사라짐 (정지 상태)
+- 새 세션의 `guest-BBB` 캐릭터가 정상 동작
+
+즉 **본인 화면에서는 "따라다니는 유령"** 으로, **다른 사람 화면에서는 "정지된 잔존 캐릭터"** 로 같은 사건이 두 가지 모습으로 보인다. issue 보고자가 "본인을 따라다닌다" 를 강조한 이유 = 본인 시점의 증상이 가장 직관적이라서.
+
+---
+
+## 3. issue 본문 의심 vs 진짜 원인 — 왜 다른가
+
+| | issue 본문 의심 | 코드 워크스루 결과 |
+|--|---|---|
+| 영역 | 백엔드 presence cleanup | 프론트엔드 자기인식 (myDisplayId stale) |
+| 동작 가설 | "서버가 LEAVE 를 못/늦게 보낸다" | "클라이언트가 자기 자신을 다른 사람으로 본다" |
+| 트리거 | 사용자가 떠남 (close/disconnect) | 사용자가 입장한 직후 STOMP onError → 토큰 재발급 |
+| 잔존 시간 | 영구 (서버가 모르므로) | 본인 화면: 영구 / 다른 화면: 30초 |
+| 누구한테 보이는가 | 떠난 사람 외 모두 | 본인+다른 사람 모두에게 보이지만 모습이 다름 |
+| 핵심 식별 단서 | (없음) | "본인을 따라다닌다" — 좌표 broadcast 가 계속 들어옴 |
+
+### 3.1 왜 의심이 빗나갔는가
+
+issue 보고자가 백엔드를 의심한 건 자연스럽다. "캐릭터가 안 사라진다" 는 표면적으로 cleanup 문제처럼 보이고, presence 시스템에서 잔존(ghost) 은 거의 항상 cleanup 누락이다. 그런데 **본 케이스의 본질은 cleanup 이 아니라 "한 사람이 다른 사람으로 인식됨"** 이다. 식별자가 어긋나는 순간 cleanup 은 정상 동작해도 잔존이 발생할 수 있다 — 사라지긴 하지만 30초가 걸리고, 그 사이에 새 식별자로 또 추가된다.
+
+### 3.2 콜드 스타트에서 가장 잘 터지는 이유
+
+콜드 스타트 = 페이지 첫 진입. 백엔드도 idle 상태일 수 있고, SockJS handshake 가 timeout 되거나 처음 한 번은 실패하기 쉬움. 그러면 onError → 토큰 삭제 → 재연결 → 새 sessionId 시퀀스가 즉시 발생. **첫 입장에서 가장 흔한 경로** 가 곧 유령 발생 경로다.
+
+### 3.3 회원 사용자에겐 안 터지는 이유
+
+`displayId() = MEMBER_PREFIX + userId` 라서 토큰을 100번 새로 받아도 `displayId` 는 `user-42` 그대로. 자기 무시 비교가 안 깨진다. **이 이슈는 게스트 한정 버그**. 운영 환경에 게스트 진입이 많을수록 빈도 증가.
+
+---
+
+## 4. 보조 원인 — 무관하진 않지만 본 이슈의 메인은 아닌 것들
+
+### 4.1 탭 강제 종료 시 STOMP DISCONNECT 지연
+
+브라우저 탭을 X 로 닫으면 SockJS heartbeat timeout 까지 (보통 25~60초) `SessionDisconnectEvent` 가 백엔드에 도달하지 않는다. 그 사이 LEAVE broadcast 가 안 나가고, 다른 클라이언트는 떠난 사람을 30초까지 본다.
+
+이건 별도 보조 원인이고, **`PositionDisconnectListener` 자체는 정상 동작 — 이벤트가 늦게 올 뿐**이다. 진짜 fix 는 클라이언트 측에서 `beforeunload` 로 graceful disconnect 시도하는 쪽에 있음.
+
+### 4.2 백엔드 위치 데이터 비영속
+
+`PositionHandler` 가 단순 broadcast 만 한다. 서버측 SessionRegistry 나 플레이어 위치 캐시 없음. 이로 인해:
+
+- 새 클라이언트가 입장해도 다른 사람이 좌표 broadcast 를 보낼 때까지 누가 어디 있는지 알 수 없음
+- 떠난 사람의 마지막 좌표를 서버가 모르므로 LEAVE 시 좌표 정보 없이 id 만 broadcast
+
+이건 **본 트랙(ghost-session) 범위 밖**이고 `ws-redis` 트랙의 SessionRegistry 영역이다. 본 노트에선 인지만 하고 fix 대상에 넣지 않는다.
+
+---
+
+## 5. 비슷한 패턴 — 시야 확장
+
+### 5.1 JWT sub claim 으로 식별하는 시스템에서 토큰 갱신 시 식별자가 바뀌는 함정
+
+본 이슈의 일반화: **"세션·토큰 ID 를 비즈니스 식별자로 쓰면 토큰 라이프사이클이 비즈니스 식별자 라이프사이클을 흔든다."**
+
+같은 함정의 다른 사례:
+
+- OAuth refresh 후 sub claim 이 바뀌는 IdP (드물지만 일부 IdP 가 그렇게 동작)
+- 익명 사용자 추적용 분석 ID 를 쿠키 만료 때마다 새로 발급 — 같은 사람이 매번 새 사용자로 카운트
+- 결제 세션 ID 를 결제 단계마다 갱신했더니 멱등키가 깨짐
+- WebSocket 연결마다 connectionId 를 비즈니스 ID 로 쓰면, reconnect 마다 "다른 사람" 이 됨
+
+**룰**: 토큰/세션 ID 는 인증·인증 라이프사이클에만 쓰고, 비즈니스 영속 식별자는 따로 둔다. 익명 사용자도 LocalStorage / 쿠키 / 백엔드 익명 user 레코드 등으로 영속 ID 를 부여해야 한다.
+
+### 5.2 WebSocket "자기 무시" 로직이 stale 상태에서 깨지는 패턴
+
+거의 모든 실시간 시스템에 자기 무시(self-echo suppression) 로직이 있다 — Slack, Discord, Figma, Excalidraw 등. 자기가 보낸 게 자기에게 돌아오는 걸 차단하기 위함.
+
+이 로직은 두 가지 가정에 의존한다:
+
+1. "내가 누구인지" 가 클라이언트 측에서 정확히 알려져 있다
+2. 그 식별자가 서버가 broadcast 에 박는 식별자와 동일하다
+
+둘 중 하나만 깨져도 자기 무시 실패. 본 이슈는 1번 가정이 깨진 케이스.
+
+같은 패턴의 다른 사례:
+
+- Figma 가 multiplayer 커서에서 자기 커서를 또 그리는 회귀 — 클라이언트가 자기 userId 캐시를 늦게 동기화한 버그였음 [추정, 정확한 PR 추적 어려움]
+- Slack 메시지가 자기에게 두 번 보이는 회귀 — local optimistic 메시지 + echo 메시지의 ID 매칭 실패
+
+**룰**: 자기 무시 로직 옆에는 **"내 식별자가 서버 broadcast 와 동일한지 검증하는 디버그 로그"** 를 항상 둔다. 식별자가 어긋나면 즉시 경고 띄울 수 있도록.
+
+### 5.3 onError 의 트리거 조건이 너무 넓은 패턴
+
+`onError` 라는 콜백 이름은 "심각한 에러" 같지만, STOMP/SockJS 에서는 다음을 모두 포함:
+
+- 일시적 네트워크 끊김
+- 서버 일시적 응답 지연 (handshake timeout)
+- 페이지 visibility 변경으로 인한 hiccup
+- 토큰 만료
+- 인증 실패
+
+이 중 "토큰 만료" 만 토큰 재발급의 정당한 사유다. 나머지는 단순 재연결로 충분. **에러 종류 구분 없이 토큰을 지우는 건 정상 토큰을 매번 폐기하는 결과**가 된다.
+
+같은 패턴의 다른 사례:
+
+- HTTP 401 만 토큰 갱신해야 하는데 5xx 도 갱신하는 인터셉터
+- gRPC UNAUTHENTICATED 만 갱신해야 하는데 UNAVAILABLE 도 갱신
+- DB connection pool 의 retry 가 모든 SQLException 을 재시도로 처리
+
+**룰**: 자동 복구 로직은 **에러 종류를 분류**하고, 종류별로 다른 처리를 한다. "에러면 다 같은 처리" 는 거의 항상 버그.
+
+---
+
+## 6. 트레이드오프 비교 — 게스트 식별자 정책
+
+본 이슈의 근본은 "게스트의 영속 식별자가 없다" 다. 정책 옵션을 비교해 둔다.
+
+### 6.1 옵션
+
+| | A. 현재 (sessionId = displayId) | B. 게스트도 영속 ID 부여 (서버측 익명 user 레코드) | C. 클라이언트 LocalStorage 에 게스트 ID 캐싱 |
+|--|---|---|---|
+| 식별자 라이프사이클 | 토큰마다 변함 | 게스트 user 레코드 생성 시 1회 발급, 영속 | 브라우저 LocalStorage 가 살아있는 동안 영속 |
+| 토큰 재발급 영향 | displayId 바뀜 (현재 버그의 원인) | displayId 안 바뀜 | displayId 안 바뀜 (LocalStorage 가 살아있다면) |
+| DB 부담 | 0 (게스트 레코드 없음) | 게스트당 1 row + 정리 정책 필요 (휴면 계정 cleanup) | 0 (서버측 없음) |
+| 보안 | sessionId 위조 어려움 (JWT 서명) | userId 위조 어려움 (JWT 서명) | LocalStorage 는 클라이언트가 마음대로 바꿈 → 인증 토큰과 연결 필요 |
+| 멀티 디바이스 | 디바이스별 다른 sessionId → 다른 사람 | 게스트 user 가 디바이스 간 공유되려면 추가 인증 필요 | LocalStorage 는 디바이스별이라 자연스럽게 디바이스 = 정체성 |
+| 데이터 마이그레이션 | 회원 가입 시 게스트 데이터 → 회원 데이터 매핑이 어려움 (게스트 ID 가 매번 달라서) | 게스트 user → 회원 user 변환이 깔끔 | 게스트 ID 를 가입 폼에 붙여 보내면 매핑 가능 |
+| 적합한 상황 | 게스트가 "임시 1회용" 인 서비스 | 게스트도 공간 꾸미기 등 영속 데이터를 가져야 하는 서비스 (우리 케이스) | 식별자 영속성만 필요하고 보안은 다른 토큰이 책임지는 경우 |
+| 실제 사용 사례 | 단순 채팅 룸·게스트 댓글 | Notion·Figma 의 익명 사용자 (Notion 의 익명 readonly 등) | Google Analytics 의 client ID, 광고 식별자 |
+
+### 6.2 본 트랙(ghost-session) 의 단기 처방
+
+위 비교는 장기 결정이고, 본 트랙이 노릴 수 있는 단기 처방은 **A 안 유지 + onError 시 토큰 보존** 이다. 즉 displayId 를 바꾸지 않는 가장 작은 변경. 장기적으로 B 안(게스트 user 레코드) 으로 가는 게 맞지만 그건 별도 도메인 결정이고 본 이슈의 즉시 fix 는 아니다.
+
+### 6.3 무엇을 잃는가
+
+A 안 유지 시 잃는 것:
+- 게스트의 데이터 영속성. 새 디바이스/브라우저 = 새 사람.
+- 회원 가입 시 게스트 시절 데이터 이관 안 됨.
+
+B 안 도입 시 잃는 것:
+- 게스트 user 레코드 정리 정책 (휴면 cleanup, 봇 abuse 방지) 비용
+- DB 스키마 변경 + 마이그레이션
+- 익명성 약화 (서버에 더 많은 흔적)
+
+본 트랙은 이 결정을 강제하지 않고 인풋만 제공한다. **"게스트 정체성을 어디에 둘 것인가" 는 별도 도메인 회의의 의제**.
+
+---
+
+## 7. Step 2 정책 결정 인풋 — 무엇을 논의해야 하는가
+
+본 트랙의 Step 2 = 정책 합의 게이트. 다음 항목을 의제로 올린다. **결론은 Step 2 에서 사용자와 합의 후 정한다 — 본 노트에서 미리 결정하지 않는다.**
+
+### 7.1 본 트랙(ghost-session) 의 진짜 fix 후보
+
+1. **게스트 토큰을 onError 마다 삭제하지 않는다**
+   - 토큰 만료(401) 때만 재발급, 그 외엔 단순 재연결
+   - 토큰 만료 판정을 어떻게 할 것인가가 부수 의제 (서버에서 401 응답을 보고 결정 vs 클라이언트에서 exp claim 을 보고 결정)
+
+2. **토큰이 어쩔 수 없이 갱신되면 myDisplayId 도 즉시 갱신**
+   - VillageScene 이 토큰 변경을 감지하고 myDisplayId 를 다시 결정
+   - 이벤트 기반 (useStomp 가 토큰 변경 이벤트 발사) vs polling 기반
+   - 이미 화면에 자기 자신이 "손님" 으로 추가된 상태라면 그 손님을 정리하는 로직도 필요 (corner case)
+
+3. **STOMP DISCONNECT 보강 — beforeunload 로 graceful disconnect**
+   - 탭 종료 시 LEAVE 가 빠르게 나가도록
+   - 보조 fix. 1·2 가 본 이슈의 메인.
+
+4. **백엔드 방어선 (선택사항)**
+   - 같은 sessionId 의 위치 broadcast 가 짧은 간격으로 두 번 들어오면 LEAVE 후 ENTER 로 처리하는 옵션
+   - 의미: 클라이언트가 myDisplayId 갱신을 빠뜨려도 서버가 이전 정체성을 정리해주는 안전망
+   - 트레이드오프: 정상 동작에 false positive 가 끼면 정상 사용자를 잠깐 끊어버릴 수 있음
+
+### 7.2 ws-redis 트랙으로 넘길 부분
+
+- **동일 userId 다중 세션 정책 (대체 / 거부 / 병행)**
+  - 사용자가 동시에 여러 디바이스/탭에서 접속할 때
+  - SessionRegistry 영역. ws-redis Step 2/3 의 의제
+
+**중요**: 본 이슈의 진짜 유령은 다중 세션 정책 부재 때문이 아니라 **게스트 토큰이 sessionId 별로 displayId 를 바꾸기 때문**이다. 표면적으로 비슷해 보이지만 다른 문제. 두 트랙의 작업이 동시에 진행되어도 충돌하지 않도록 영역 구분을 명확히 한다.
+
+---
+
+## 8. 진단 과정에서 배운 것
+
+### 8.1 "보고자 의심 → 코드 워크스루 → 진짜 원인" 의 격차
+
+issue 본문이 의심한 영역과 실제 원인 영역이 완전히 다르면, **표면 증상 → 의심 → 가설 검증** 사이클의 의심 단계에서 한 번 더 의심해야 한다는 신호다.
+
+본 케이스는 "캐릭터가 안 사라진다" → "cleanup 문제" 라는 자연스러운 추론이 함정이었다. 진짜 단서는 "**본인을 따라다닌다**" 라는 표현이었고, 이게 좌표 broadcast 가 계속 들어오는 시나리오를 암시했다.
+
+**룰**: 보고된 증상 중 "이상하게 구체적인 표현" 을 그냥 넘기지 않는다. 그 안에 진짜 단서가 있다.
+
+### 8.2 식별자가 라이프사이클을 가로지르는지 점검
+
+새 식별자 도입 시:
+
+- 어떤 라이프사이클(요청·세션·토큰·사용자 영속) 에 속하는가
+- 그 식별자가 다른 라이프사이클의 코드에서 캐시되는가
+- 캐시된 시점과 캐시된 식별자의 라이프사이클이 어긋나면 무엇이 깨지는가
+
+본 이슈는 **세션 라이프사이클의 식별자(sessionId) 가 비즈니스 라이프사이클의 캐시(myDisplayId) 에 박힌** 케이스. 이런 결합은 진단이 어렵다 — 코드 한 곳만 봐서는 안 보이고, 라이프사이클 관계를 추적해야 보인다.
+
+### 8.3 콜드 스타트에서만 보이는 버그의 무서움
+
+콜드 스타트 = 첫 진입. 신규 사용자가 가장 먼저 만나는 경로. 여기서 발생하는 버그는:
+
+- 사용자가 "이 서비스 안 되는구나" 결론을 내고 떠남
+- 재현 비율이 100% 가 아니라 50% 정도면 "운 나쁘면 깨지는 서비스" 인상
+- 운영자가 자기 기계로 테스트하면 (이미 토큰이 cached 라서) 절대 안 보임
+
+**룰**: 신규 사용자 시뮬레이션을 정기적으로 한다 — 모든 토큰·캐시·세션 데이터를 지운 후 첫 진입을 해본다.
+
+---
+
+## 9. 나중에 돌아보면
+
+### 9.1 이 진단이 틀렸다고 느낄 시점
+
+- Step 2 의 fix 후 같은 증상이 다시 보고되면 — 진단의 95% 가설이 빗나갔다는 신호. 4.1 (탭 종료 STOMP 지연) 이나 4.2 (백엔드 비영속) 이 메인이었을 가능성 재검토.
+- 회원 사용자에게도 같은 증상이 보고되면 — 본 진단(게스트 한정) 자체가 틀렸다는 신호. JWT refresh 동작·동시 접속 등 다른 메커니즘 조사.
+- "본인을 따라다닌다" 가 아니라 "정지 상태로 계속 남아있다" 가 메인 증상이 되면 — 본 진단의 메커니즘과 다른 시나리오. 진짜 cleanup 문제일 수 있음.
+
+### 9.2 Step 2 의 fix 가 끝난 후 이 노트가 할 일
+
+- 후속 노트(56·57 예약) 가 생기면 본 노트에서 "그 후 이렇게 해결됨" 으로 링크
+- 같은 패턴(라이프사이클 가로지르는 식별자) 회귀 방지 체크리스트가 만들어지면 본 노트 §8.2 룰을 컨벤션 문서로 승격 검토
+
+### 9.3 스케일이 바뀌면
+
+| 스케일 | 본 진단의 유효성 |
+|---|---|
+| 게스트 비중 낮음 + 회원 위주 | 본 이슈의 빈도가 자연스럽게 줄어듦. 단, 회원의 토큰 refresh 시나리오에서 비슷한 메커니즘 가능성은 별도 조사 필요. |
+| 게스트 비중 높음 + 동시 접속 많음 | 빈도 폭증. fix 우선순위 최상위. |
+| 다중 디바이스 시나리오 등장 | ws-redis 트랙의 SessionRegistry 영역과 본 트랙이 만난다. 두 트랙의 정책 통합 필요. |
+| 모바일 비중 증가 | 모바일은 백그라운드 전환·네트워크 변경이 잦아 onError 발생 빈도가 높음 → 본 이슈 빈도 증가. |
+
+---
+
+## 10. 더 공부할 거리
+
+### 10.1 직접 관련 (이 프로젝트)
+
+- [learning/15 — WebSocket + STOMP 동작 원리](./15-websocket-stomp-deep-dive.md) — STOMP 라이프사이클·DISCONNECT 이벤트의 정확한 발사 시점
+- [learning/24 — STOMP JWT 인증](./24-stomp-websocket-jwt-channel-interceptor.md) — `AuthenticatedUser` 가 어떻게 만들어지는가, displayId 의 origin
+- [learning/45 — Raw WebSocket + Redis Pub/Sub 재설계 설계서](./45-websocket-redis-pubsub-redesign.md) — SessionRegistry 영역의 정책 결정. ws-redis 트랙의 후속 의제와 만나는 지점
+- [learning/25 — 배치 브로드캐스트 + 멀티유저 메시지 귀속](./25-batch-broadcast-multiuser-message-attribution.md) — "내 메시지" 판별의 일반론. 자기 무시 로직의 다른 사례
+
+### 10.2 표준·공식 문서
+
+- [STOMP 1.2 Specification — DISCONNECT frame](https://stomp.github.io/stomp-specification-1.2.html#DISCONNECT) — graceful disconnect 의 표준 동작
+- [SockJS protocol — heartbeat](https://github.com/sockjs/sockjs-protocol) — heartbeat timeout 이 disconnect 감지에 미치는 영향
+- [Spring Messaging — SessionDisconnectEvent](https://docs.spring.io/spring-framework/reference/web/websocket/stomp/application-context-events.html) — Spring 의 disconnect 이벤트 발사 조건
+- [MDN — beforeunload event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event) — 탭 종료 시 graceful disconnect 의 hook
+
+### 10.3 비슷한 패턴의 실제 회귀 사례
+
+- [Figma multiplayer engineering blog](https://www.figma.com/blog/how-figmas-multiplayer-technology-works/) — multiplayer 식별자 동기화의 일반론
+- [Slack engineering — local message echo handling](https://slack.engineering/) — optimistic 메시지 + echo 메시지 매칭의 일반 패턴
+- [Discord engineering — voice/presence cleanup](https://discord.com/blog/engineering) — presence cleanup 의 실전 디테일
+
+### 10.4 식별자·라이프사이클 일반론
+
+- ["Identity and authority in distributed systems"](https://martinfowler.com/articles/) — Fowler 류의 Identity 패턴 정리
+- [OAuth 2.0 — sub claim 의 영속성 보장](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.2) — JWT sub claim 의 정의와 보장 범위
+- [User identification in web analytics](https://support.google.com/analytics/answer/) — GA 의 client ID 영속성 처리 (LocalStorage 사례)
+
+### 10.5 추가로 파볼 가치
+
+- 이 프로젝트의 게스트 가입 → 회원 전환 시 데이터 이관 시나리오. 현재는 데이터가 거의 없어서 문제 안 되지만, 공간 꾸미기 등 게스트 데이터가 늘어나면 §6 의 B 안 결정이 강제됨.
+- WebSocket reconnect 시 클라이언트 측에서 자체 식별자(deviceId 같은) 를 부여하고 서버로 전달하는 패턴. 본 이슈를 디바이스 측 영속성으로 푸는 또 다른 방향.
+
+---
+
+## 부록 A. 진단의 핵심 코드 위치 모음
+
+```text
+[프론트엔드]
+frontend/src/lib/websocket/useStomp.ts:67-79       토큰 ensure (없으면 게스트 발급)
+frontend/src/lib/websocket/useStomp.ts:133-144     onError → 토큰 삭제 + 재연결
+frontend/src/game/scenes/VillageScene.ts:104-109   create() — myDisplayId 결정 호출
+frontend/src/game/scenes/VillageScene.ts:449-466   resolveMyDisplayId() — 1회만 호출되는 자기 식별
+frontend/src/game/scenes/VillageScene.ts:485-502   handleRemotePosition + 자기 무시 비교
+frontend/src/game/scenes/VillageScene.ts:543-555   sweepStalePlayers (방어선, 30초)
+
+[백엔드]
+backend/.../AuthenticatedUser.java:41-46           displayId() — 게스트 sessionId 의존
+backend/.../PositionHandler.java                   비영속 broadcast 핸들러
+backend/.../PositionDisconnectListener.java        STOMP DISCONNECT → LEAVE broadcast
+```
+
+## 부록 B. 진단 검증 한계
+
+본 진단은 **코드 워크스루 + 시나리오 추론** 으로 도출됐다. 다음은 직접 재현으로 검증하지 않았다:
+
+- 운영 환경 `ghworld.co` 에서 토큰 로깅을 켜고 실제 onError 시퀀스를 캡처
+- 다중 클라이언트 동시 접속 환경에서 "본인을 따라다니는" 증상 직접 관찰
+- `myDisplayId` 와 broadcast 의 `pos.id` 값을 콘솔 로그로 비교
+
+**Step 2 진입 전 권장**: 운영 환경에서 디버그 로그를 임시로 켜서 위 3개를 실측하면 진단 신뢰도가 95% → 99% 로 올라간다. 단, 운영 환경 로그를 켜는 것 자체의 영향(개인정보·성능)을 감안.
+
+---
+
+> 이 노트는 ghost-session 트랙의 첫 학습 기록이다. Step 2 (정책 합의 게이트) 의 출발점이 되며, 본 노트의 §7 인풋이 합의되면 fix 가 시작된다. **본 노트는 진단 + 인풋이고, fix 는 별도 작업이다.**

--- a/docs/learning/INDEX.md
+++ b/docs/learning/INDEX.md
@@ -65,6 +65,7 @@
 | [27](./27-realtime-chat-code-review-patterns.md) | 실시간 채팅 종합 리뷰 이슈 | 4개 전문 에이전트 리뷰에서 뽑은 패턴 |
 | [44](./44-spring-stomp-external-broker-choice.md) | Spring STOMP 외부 Broker 선택 트레이드오프 | 왜 RabbitMQ고 Redis Pub/Sub이 아닌가 — `enableStompBrokerRelay()` 의 전제 |
 | [45](./45-websocket-redis-pubsub-redesign.md) | Raw WebSocket + Redis Pub/Sub 재설계 설계서 | STOMP·Simple Broker 걷어내기 전 함정 예방 — 채널톡 O(M×N) / LINE LIVE actor+bridge 패턴 흡수 |
+| [54](./54-presence-cleanup-ghost-character-diagnosis.md) | "본인을 따라다니는 유령 캐릭터" 진단기 | issue #28 의심(백엔드 cleanup) vs 진짜 원인(프론트엔드 myDisplayId stale) — 게스트 토큰 재발급 → sessionId 변경 → 자기 무시 비교 실패 |
 
 ## UI · 프론트엔드
 

--- a/docs/learning/RESERVED.md
+++ b/docs/learning/RESERVED.md
@@ -12,7 +12,7 @@
 
 ---
 
-## 예약 현황 (마지막 사용 번호: 50, 53은 ws-redis worktree 점유 중)
+## 예약 현황 (마지막 사용 번호: 54, 53은 ws-redis worktree 점유 중)
 
 | 번호 | 트랙 | 예상 주제 | 상태 |
 |------|------|----------|------|
@@ -24,11 +24,11 @@
 | 51   | `s3-media` | (트랙 시작 시 첫 노트 — S3 도입 결정 + 비용 정책) | 미사용 |
 | 52   | `s3-media` | (예비) | 미사용 |
 | 53   | `ws-redis` | 헥사고날 outbound port 호출자 룰 — worktree 미푸시 영역에서 사용 중 (정합성 머지 시 "사용 완료" 처리) | 사용 중 (worktree) |
-| 54   | `ghost-session` | presence cleanup 분석 — 세션 종료/지연 연결 시 유령 캐릭터 원인 진단 | 미사용 |
-| 55   | `ghost-session` | WebSocket 동시 세션 정책 (동일 userId 다중 connection 핸들링 — 대체/거부/병행) | 미사용 |
-| 56   | `ghost-session` | (예비 — 수정 후 회귀 방지 패턴) | 미사용 |
-| 57   | `ghost-session` | (예비) | 미사용 |
-| 58   | `ghost-session` | (예비) | 미사용 |
+| 54   | `ghost-session` | presence cleanup 분석 — 세션 종료/지연 연결 시 유령 캐릭터 원인 진단 | 사용 완료 |
+| 55   | (반환) | (구 ghost-session — 다중 세션 정책. #28 진단 결과 본 트랙 범위 외로 판정, 별도 이슈로 분리) | 반환 — 재예약 가능 |
+| 56   | `ghost-session` | (예비 — fix 회고/회귀 방지 패턴 등) | 미사용 |
+| 57   | (반환) | (구 ghost-session 예비) | 반환 — 재예약 가능 |
+| 58   | (반환) | (구 ghost-session 예비) | 반환 — 재예약 가능 |
 
 > 59번 이후는 트랙 추가 시 본 표에 5번 단위로 예약.
 

--- a/frontend/src/game/scenes/VillageScene.ts
+++ b/frontend/src/game/scenes/VillageScene.ts
@@ -2,6 +2,7 @@ import Phaser from 'phaser';
 
 import type { PositionBroadcast } from '@/lib/websocket/stompClient';
 
+import { getDisplayIdFromToken } from '../../lib/auth';
 import {
   onMyTypingUpdate,
   onNpcTypingUpdate,
@@ -10,6 +11,7 @@ import {
 } from '../../lib/websocket/positionBridge';
 import type { TypingBroadcast } from '../../lib/websocket/stompClient';
 import { sendPosition } from '../../lib/websocket/stompClient';
+import { onDisplayIdChange } from '../../lib/websocket/tokenBridge';
 
 const SPEED = 160;
 const PLAYER_RADIUS = 14;
@@ -55,6 +57,7 @@ export class VillageScene extends Phaser.Scene {
   private unsubscribeTyping: (() => void) | null = null;
   private unsubscribeNpcTyping: (() => void) | null = null;
   private unsubscribeMyTyping: (() => void) | null = null;
+  private unsubscribeDisplayId: (() => void) | null = null;
   private myDisplayId: string | null = null;
   private npcContainer: Phaser.GameObjects.Container | null = null;
   private npcBubble: Phaser.GameObjects.Container | null = null;
@@ -105,8 +108,12 @@ export class VillageScene extends Phaser.Scene {
       this.handleRemotePosition(pos);
     });
 
-    // 내 displayId 결정 (토큰에서 추출)
-    this.resolveMyDisplayId();
+    // 토큰 변경 이벤트 구독 — useStomp 가 토큰을 발급/갱신할 때마다 myDisplayId 동기화 (#28).
+    // 이벤트 도착 전 fallback 으로 현재 localStorage 값 즉시 반영.
+    this.myDisplayId = getDisplayIdFromToken();
+    this.unsubscribeDisplayId = onDisplayIdChange((id) => {
+      this.myDisplayId = id;
+    });
 
     // 다른 유저 타이핑 구독
     this.unsubscribeTyping = onTypingUpdate((data) => {
@@ -129,6 +136,7 @@ export class VillageScene extends Phaser.Scene {
       this.unsubscribeTyping?.();
       this.unsubscribeNpcTyping?.();
       this.unsubscribeMyTyping?.();
+      this.unsubscribeDisplayId?.();
     });
 
     this.scale.on('resize', (gameSize: Phaser.Structs.Size) => {
@@ -445,25 +453,6 @@ export class VillageScene extends Phaser.Scene {
   }
 
   // --- 위치 공유 ---
-
-  private resolveMyDisplayId() {
-    const token = localStorage.getItem('accessToken');
-    if (!token) {
-      this.myDisplayId = null;
-      return;
-    }
-    try {
-      const base64Url = token.split('.')[1];
-      const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-      const payload: { role: string; sub: string } = JSON.parse(atob(base64)) as {
-        role: string;
-        sub: string;
-      };
-      this.myDisplayId = payload.role === 'GUEST' ? payload.sub : `user-${payload.sub}`;
-    } catch {
-      this.myDisplayId = null;
-    }
-  }
 
   private sendPositionThrottled(time: number) {
     if (time - this.lastPositionSentAt < POSITION_SEND_INTERVAL) return;

--- a/frontend/src/lib/auth.test.ts
+++ b/frontend/src/lib/auth.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { getDisplayIdFromToken, isTokenExpired } from './auth';
+
+/**
+ * #28 fix 핵심 — 만료된 토큰을 STOMP 로 보내지 않도록 사전 차단.
+ * 토큰의 displayId 는 서버 AuthenticatedUser.displayId() 와 동일 규칙이어야 한다.
+ */
+
+function makeToken(payload: Record<string, unknown>): string {
+  const body = btoa(JSON.stringify(payload));
+  return `header.${body}.signature`;
+}
+
+describe('auth — JWT 토큰 유틸 (#28 fix)', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe('isTokenExpired', () => {
+    it('exp 가 과거면 만료로 판정한다', () => {
+      // Given
+      const past = Math.floor(Date.now() / 1000) - 10;
+      const token = makeToken({ exp: past, sub: 'guest-x', role: 'GUEST' });
+
+      // When / Then
+      expect(isTokenExpired(token)).toBe(true);
+    });
+
+    it('exp 가 충분히 미래면 유효로 판정한다', () => {
+      // Given
+      const future = Math.floor(Date.now() / 1000) + 3600;
+      const token = makeToken({ exp: future, sub: 'guest-x', role: 'GUEST' });
+
+      // When / Then
+      expect(isTokenExpired(token)).toBe(false);
+    });
+
+    it('exp 가 마진(기본 60s) 이내면 만료 임박으로 판정한다', () => {
+      // Given: 30초 후 만료 — 60초 마진보다 가까움
+      const soon = Math.floor(Date.now() / 1000) + 30;
+      const token = makeToken({ exp: soon, sub: 'guest-x', role: 'GUEST' });
+
+      // When / Then: 사전 갱신 트리거
+      expect(isTokenExpired(token)).toBe(true);
+    });
+
+    it('토큰 인자가 없고 localStorage 도 비어 있으면 만료로 판정한다', () => {
+      // Given: localStorage 비어 있음
+      // When / Then
+      expect(isTokenExpired()).toBe(true);
+    });
+
+    it('exp claim 이 없으면 만료로 판정한다 (안전한 기본값)', () => {
+      // Given: exp 누락 토큰 — 비정상 토큰은 갱신 트리거
+      const token = makeToken({ sub: 'guest-x', role: 'GUEST' });
+
+      // When / Then
+      expect(isTokenExpired(token)).toBe(true);
+    });
+
+    it('잘못된 형식 토큰은 만료로 판정한다', () => {
+      // Given: base64 디코딩 불가능
+      // When / Then
+      expect(isTokenExpired('not-a-jwt')).toBe(true);
+    });
+
+    it('인자 없을 때 localStorage 의 토큰을 읽는다', () => {
+      // Given
+      const future = Math.floor(Date.now() / 1000) + 3600;
+      localStorage.setItem('accessToken', makeToken({ exp: future, sub: 'g', role: 'GUEST' }));
+
+      // When / Then
+      expect(isTokenExpired()).toBe(false);
+    });
+  });
+
+  describe('getDisplayIdFromToken', () => {
+    it('GUEST 토큰의 displayId 는 sub 그대로다 (서버 AuthenticatedUser 와 일치)', () => {
+      // Given
+      const token = makeToken({ sub: 'guest-abc-123', role: 'GUEST', exp: 9999999999 });
+
+      // When / Then
+      expect(getDisplayIdFromToken(token)).toBe('guest-abc-123');
+    });
+
+    it('MEMBER 토큰의 displayId 는 "user-{sub}" 다', () => {
+      // Given
+      const token = makeToken({ sub: '42', role: 'MEMBER', exp: 9999999999 });
+
+      // When / Then
+      expect(getDisplayIdFromToken(token)).toBe('user-42');
+    });
+
+    it('role 이 없으면 null 을 반환한다 (자기인식 비활성화)', () => {
+      // Given
+      const token = makeToken({ sub: 'guest-x', exp: 9999999999 });
+
+      // When / Then
+      expect(getDisplayIdFromToken(token)).toBeNull();
+    });
+
+    it('토큰이 없으면 null 을 반환한다', () => {
+      // Given: localStorage 비어 있음
+      // When / Then
+      expect(getDisplayIdFromToken()).toBeNull();
+    });
+
+    it('인자 없을 때 localStorage 의 토큰을 읽는다', () => {
+      // Given
+      localStorage.setItem(
+        'accessToken',
+        makeToken({ sub: 'guest-z', role: 'GUEST', exp: 9999999999 }),
+      );
+
+      // When / Then
+      expect(getDisplayIdFromToken()).toBe('guest-z');
+    });
+  });
+});

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,19 +1,59 @@
 /**
  * JWT 토큰에서 사용자 정보를 추출하는 유틸리티.
  *
- * 서버 JWT의 sub claim에 userId가 들어있다 (MEMBER 토큰 기준).
+ * 서버 JWT의 sub claim에 userId(MEMBER) 또는 guest-UUID(GUEST)가 들어있다.
  * 외부 라이브러리 없이 base64 디코딩으로 payload를 파싱한다.
  */
 
-export function getUserIdFromToken(): number | null {
-  const token = localStorage.getItem('accessToken');
-  if (!token) return null;
+interface TokenPayload {
+  sub?: string;
+  role?: 'MEMBER' | 'GUEST';
+  exp?: number;
+}
 
+const TOKEN_KEY = 'accessToken';
+const MEMBER_DISPLAY_ID_PREFIX = 'user-';
+/** 만료 임박 마진 — 서버 도달 전에 갱신해 'Invalid or expired token' 사전 차단 */
+const EXPIRY_MARGIN_MS = 60_000;
+
+function decodePayload(token: string): TokenPayload | null {
   try {
-    const payload = token.split('.')[1];
-    const decoded = JSON.parse(atob(payload)) as { sub?: string };
-    return decoded.sub ? Number(decoded.sub) : null;
+    const part = token.split('.')[1];
+    const base64 = part.replace(/-/g, '+').replace(/_/g, '/');
+    return JSON.parse(atob(base64)) as TokenPayload;
   } catch {
     return null;
   }
+}
+
+export function getUserIdFromToken(): number | null {
+  const token = localStorage.getItem(TOKEN_KEY);
+  if (!token) return null;
+  const payload = decodePayload(token);
+  return payload?.sub ? Number(payload.sub) : null;
+}
+
+/**
+ * 토큰의 displayId 를 반환한다 (서버 AuthenticatedUser.displayId() 와 동일 규칙).
+ * MEMBER: "user-{sub}", GUEST: sub (guest-UUID).
+ */
+export function getDisplayIdFromToken(token?: string | null): string | null {
+  const raw = token ?? localStorage.getItem(TOKEN_KEY);
+  if (!raw) return null;
+  const payload = decodePayload(raw);
+  if (!payload?.sub || !payload.role) return null;
+  return payload.role === 'GUEST' ? payload.sub : `${MEMBER_DISPLAY_ID_PREFIX}${payload.sub}`;
+}
+
+/**
+ * 토큰이 만료되었거나 임박했는지 검사한다.
+ * 만료된 토큰을 STOMP CONNECT 로 보내면 서버가 'Invalid or expired token' 으로 거부하고,
+ * 클라이언트는 새 토큰(=새 sessionId)을 발급받아 자기인식이 깨진다 (#28).
+ */
+export function isTokenExpired(token?: string | null, marginMs = EXPIRY_MARGIN_MS): boolean {
+  const raw = token ?? localStorage.getItem(TOKEN_KEY);
+  if (!raw) return true;
+  const payload = decodePayload(raw);
+  if (!payload?.exp) return true;
+  return payload.exp * 1000 <= Date.now() + marginMs;
 }

--- a/frontend/src/lib/websocket/tokenBridge.test.ts
+++ b/frontend/src/lib/websocket/tokenBridge.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { emitDisplayIdChange, onDisplayIdChange } from './tokenBridge';
+
+/**
+ * #28 fix — useStomp 의 토큰 발급/갱신을 VillageScene 의 myDisplayId 에 동기화하는 채널.
+ * positionBridge 와 같은 다중 리스너 + unsubscribe 컨벤션을 따른다.
+ */
+
+describe('tokenBridge — displayId 동기화 (#28 fix)', () => {
+  it('emit 시 등록된 모든 리스너가 호출된다', () => {
+    // Given: 두 리스너 등록 (예: VillageScene + 잠재 다른 구독자)
+    const a = vi.fn();
+    const b = vi.fn();
+    const offA = onDisplayIdChange(a);
+    const offB = onDisplayIdChange(b);
+
+    // When
+    emitDisplayIdChange('user-42');
+
+    // Then
+    expect(a).toHaveBeenCalledWith('user-42');
+    expect(b).toHaveBeenCalledWith('user-42');
+
+    offA();
+    offB();
+  });
+
+  it('unsubscribe 후에는 리스너가 더 호출되지 않는다 (씬 SHUTDOWN 정리)', () => {
+    // Given
+    const listener = vi.fn();
+    const off = onDisplayIdChange(listener);
+
+    // When
+    off();
+    emitDisplayIdChange('guest-x');
+
+    // Then
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('null emit 으로 displayId 해제를 전파할 수 있다 (cleanup)', () => {
+    // Given: useStomp cleanup 시 myDisplayId 를 null 로 되돌리는 시나리오
+    const listener = vi.fn();
+    const off = onDisplayIdChange(listener);
+
+    // When
+    emitDisplayIdChange(null);
+
+    // Then
+    expect(listener).toHaveBeenCalledWith(null);
+
+    off();
+  });
+});

--- a/frontend/src/lib/websocket/tokenBridge.ts
+++ b/frontend/src/lib/websocket/tokenBridge.ts
@@ -1,0 +1,23 @@
+type DisplayIdListener = (displayId: string | null) => void;
+
+/**
+ * STOMP ↔ Phaser displayId 동기화 브릿지.
+ *
+ * useStomp 가 토큰을 발급/사용할 때마다 emitDisplayIdChange 를 호출한다.
+ * VillageScene 은 onDisplayIdChange 로 구독해 myDisplayId 를 갱신,
+ * 자기 broadcast 를 정확히 자기로 인식한다 (#28 fix 핵심).
+ */
+const listeners = new Set<DisplayIdListener>();
+
+export function onDisplayIdChange(callback: DisplayIdListener): () => void {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+export function emitDisplayIdChange(displayId: string | null): void {
+  for (const listener of listeners) {
+    listener(displayId);
+  }
+}

--- a/frontend/src/lib/websocket/useStomp.ts
+++ b/frontend/src/lib/websocket/useStomp.ts
@@ -85,17 +85,36 @@ export function useStomp(): void {
      * 토큰을 결정한다 — localStorage 에 유효한 토큰이 있으면 재사용, 없거나 만료 임박이면 새로 발급.
      * 만료된 토큰을 STOMP CONNECT 로 보내면 서버 거부 → 새 sessionId → 자기인식 깨짐 (#28).
      * 사전 체크로 그 트리거 자체를 차단한다.
+     *
+     * 게스트만 자동 재발급한다. 멤버 토큰은 만료되어도 토큰을 그대로 두고 서버가 명시적으로
+     * 거부하게 둔다 — 자동 게스트 다운그레이드는 멤버 신원 상실로 이어진다 (Codex P1, #36 review).
+     * 멤버 토큰 자동 갱신은 별도 트랙(refresh token / sliding session) 에서 다룬다.
      */
     const ensureValidToken = async (): Promise<string | null> => {
       const stored = localStorage.getItem('accessToken');
-      if (stored && !isTokenExpired(stored)) return stored;
-      if (stored) {
-        console.log('[useStomp] 토큰 만료 임박/만료 — 사전 갱신');
-        localStorage.removeItem('accessToken');
+
+      if (!stored) {
+        const fresh = await issueGuestToken();
+        if (fresh) localStorage.setItem('accessToken', fresh);
+        return fresh;
       }
-      const fresh = await issueGuestToken();
-      if (fresh) localStorage.setItem('accessToken', fresh);
-      return fresh;
+
+      if (!isTokenExpired(stored)) return stored;
+
+      const role = parseTokenRole(stored);
+      if (role === 'GUEST') {
+        console.log('[useStomp] 게스트 토큰 만료 임박/만료 — 사전 갱신');
+        localStorage.removeItem('accessToken');
+        const fresh = await issueGuestToken();
+        if (fresh) localStorage.setItem('accessToken', fresh);
+        return fresh;
+      }
+
+      // 멤버 토큰 만료 — 자동 게스트 다운그레이드 차단. 토큰 그대로 두고 서버 거부 시 onError 에서 처리.
+      console.warn(
+        '[useStomp] 멤버 토큰 만료 임박/만료 — 자동 갱신 미지원, 서버 거부 시 재로그인 필요',
+      );
+      return stored;
     };
 
     const connect = async () => {
@@ -165,9 +184,19 @@ export function useStomp(): void {
         if (isAuthError) {
           consecutiveAuthErrors += 1;
           if (consecutiveAuthErrors >= AUTH_ERROR_THRESHOLD) {
-            console.log('[useStomp] 인증 에러 — 토큰 갱신 후 재연결');
-            localStorage.removeItem('accessToken');
+            const stored = localStorage.getItem('accessToken');
+            const role = parseTokenRole(stored);
             consecutiveAuthErrors = 0;
+
+            if (role === 'MEMBER') {
+              // 멤버 인증 에러 — 자동 게스트 다운그레이드 금지 (Codex P1).
+              // 무한 루프 방어를 위해 재연결도 시도하지 않는다. 사용자가 재로그인 해야 함.
+              console.warn('[useStomp] 멤버 인증 실패 — 재연결 중단, 재로그인 필요');
+              return;
+            }
+            // 게스트 또는 토큰 없음 → 새 게스트 발급
+            console.log('[useStomp] 게스트 인증 에러 — 토큰 갱신 후 재연결');
+            localStorage.removeItem('accessToken');
           }
         }
         // 일반 에러(네트워크·timeout 등)는 토큰 그대로 재연결 — sessionId 유지로 자기인식 보존

--- a/frontend/src/lib/websocket/useStomp.ts
+++ b/frontend/src/lib/websocket/useStomp.ts
@@ -2,9 +2,10 @@
 
 import { useEffect, useRef } from 'react';
 
-import type { StompSubscription } from '@stomp/stompjs';
+import type { IFrame, StompSubscription } from '@stomp/stompjs';
 
 import apiClient from '@/lib/api/client';
+import { getDisplayIdFromToken, isTokenExpired } from '@/lib/auth';
 import { useChatStore } from '@/store/useChatStore';
 import type { ChatMessage, MessageResponse } from '@/types/chat';
 
@@ -16,8 +17,14 @@ import {
   subscribeToPositions,
   subscribeToTyping,
 } from './stompClient';
+import { emitDisplayIdChange } from './tokenBridge';
 
 const VILLAGE_CHAT_TOPIC = 'village';
+const RECONNECT_DELAY_MS = 3_000;
+/** STOMP 인증 실패 메시지 — 서버 StompAuthChannelInterceptor 와 정확히 일치해야 함 */
+const TOKEN_INVALID_MESSAGE = 'Invalid or expired token';
+/** 같은 인증 에러가 연속 N회 발생하면 진짜 만료로 간주하고 토큰 갱신 (무한 루프 방어) */
+const AUTH_ERROR_THRESHOLD = 1;
 
 function parseTokenRole(token: string | null): string | null {
   if (!token) return null;
@@ -25,6 +32,19 @@ function parseTokenRole(token: string | null): string | null {
     const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
     return (JSON.parse(atob(base64)) as { role?: string }).role ?? null;
   } catch {
+    return null;
+  }
+}
+
+async function issueGuestToken(): Promise<string | null> {
+  try {
+    const apiBase = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
+    const res = await fetch(`${apiBase}/api/v1/auth/guest`, { method: 'POST' });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { accessToken: string };
+    return data.accessToken;
+  } catch (err) {
+    console.warn('[useStomp] 게스트 토큰 발급 실패', err);
     return null;
   }
 }
@@ -59,25 +79,27 @@ export function useStomp(): void {
 
   useEffect(() => {
     let cancelled = false;
+    let consecutiveAuthErrors = 0;
+
+    /**
+     * 토큰을 결정한다 — localStorage 에 유효한 토큰이 있으면 재사용, 없거나 만료 임박이면 새로 발급.
+     * 만료된 토큰을 STOMP CONNECT 로 보내면 서버 거부 → 새 sessionId → 자기인식 깨짐 (#28).
+     * 사전 체크로 그 트리거 자체를 차단한다.
+     */
+    const ensureValidToken = async (): Promise<string | null> => {
+      const stored = localStorage.getItem('accessToken');
+      if (stored && !isTokenExpired(stored)) return stored;
+      if (stored) {
+        console.log('[useStomp] 토큰 만료 임박/만료 — 사전 갱신');
+        localStorage.removeItem('accessToken');
+      }
+      const fresh = await issueGuestToken();
+      if (fresh) localStorage.setItem('accessToken', fresh);
+      return fresh;
+    };
 
     const connect = async () => {
-      let token = localStorage.getItem('accessToken');
-
-      // 토큰이 없으면 게스트 토큰 자동 발급 (게스트 토큰 = 익명 접속)
-      if (!token) {
-        try {
-          const apiBase = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
-          const res = await fetch(`${apiBase}/api/v1/auth/guest`, { method: 'POST' });
-          if (res.ok) {
-            const data = (await res.json()) as { accessToken: string };
-            token = data.accessToken;
-            localStorage.setItem('accessToken', token);
-          }
-        } catch (err) {
-          console.warn('[useStomp] 게스트 토큰 발급 실패', err);
-        }
-      }
-
+      const token = await ensureValidToken();
       if (cancelled) return;
 
       if (!token) {
@@ -86,6 +108,9 @@ export function useStomp(): void {
         return;
       }
 
+      // 자기인식 동기화 — 토큰이 결정된 시점에 displayId 를 Phaser 측에 전달
+      emitDisplayIdChange(getDisplayIdFromToken(token));
+
       console.log('[useStomp] Connecting to STOMP server');
       setConnectionStatus('connecting');
 
@@ -93,6 +118,7 @@ export function useStomp(): void {
         if (cancelled) return;
         console.log('[useStomp] STOMP connected, subscribing to village chat');
         setConnectionStatus('connected');
+        consecutiveAuthErrors = 0;
 
         // 이전 대화 10개 로드 (멤버만 — 게스트는 403)
         const tokenPayload = parseTokenRole(token);
@@ -130,27 +156,43 @@ export function useStomp(): void {
         });
       };
 
-      const onError = (err: import('@stomp/stompjs').IFrame) => {
+      const onError = (err: IFrame) => {
         console.error('[useStomp] STOMP error:', err);
         setConnectionStatus('error');
-        // 토큰이 만료/무효한 경우 삭제 후 게스트 토큰으로 재연결 시도
-        localStorage.removeItem('accessToken');
-        if (!cancelled) {
-          console.log('[useStomp] 재연결 시도 (게스트 토큰 재발급)');
-          setTimeout(() => {
-            if (!cancelled) void connect();
-          }, 3_000);
+        if (cancelled) return;
+
+        const isAuthError = err.headers.message === TOKEN_INVALID_MESSAGE;
+        if (isAuthError) {
+          consecutiveAuthErrors += 1;
+          if (consecutiveAuthErrors >= AUTH_ERROR_THRESHOLD) {
+            console.log('[useStomp] 인증 에러 — 토큰 갱신 후 재연결');
+            localStorage.removeItem('accessToken');
+            consecutiveAuthErrors = 0;
+          }
         }
+        // 일반 에러(네트워크·timeout 등)는 토큰 그대로 재연결 — sessionId 유지로 자기인식 보존
+        setTimeout(() => {
+          if (!cancelled) void connect();
+        }, RECONNECT_DELAY_MS);
       };
 
       connectWithAuth(token, onConnected, onError);
     };
+
+    // 탭 종료 시 graceful disconnect — SockJS heartbeat timeout 까지 기다리지 않고 즉시 LEAVE 발송 (3-D)
+    const handleUnload = () => {
+      disconnectStomp();
+    };
+    window.addEventListener('beforeunload', handleUnload);
+    window.addEventListener('pagehide', handleUnload);
 
     void connect();
 
     return () => {
       cancelled = true;
       console.log('[useStomp] Cleanup: disconnecting');
+      window.removeEventListener('beforeunload', handleUnload);
+      window.removeEventListener('pagehide', handleUnload);
       chatSubRef.current?.unsubscribe();
       chatSubRef.current = null;
       posSubRef.current?.unsubscribe();
@@ -159,6 +201,7 @@ export function useStomp(): void {
       typingSubRef.current = null;
       disconnectStomp();
       setConnectionStatus('disconnected');
+      emitDisplayIdChange(null);
     };
   }, [addMessage, prependMessages, setConnectionStatus, setNpcTyping]);
 }


### PR DESCRIPTION
## Summary

운영(`ghworld.co`)에서 보고된 #28 — 본인을 따라다니는 유령 캐릭터 — 의 진짜 원인은 백엔드 cleanup 누락이 아니라 **게스트 토큰 만료로 인한 클라이언트 자기인식 stale**. 토큰 사전 만료 검사 + onError 메시지 분기 + tokenBridge 도입으로 근본 해결.

상세 진단: [`docs/learning/54-presence-cleanup-ghost-character-diagnosis.md`](./docs/learning/54-presence-cleanup-ghost-character-diagnosis.md)

## Why

- 게스트 JWT 의 `displayId` = `sub` (guest-UUID) — 토큰 갱신 시 sessionId 가 바뀜
- `useStomp.onError` 가 모든 에러에서 `localStorage` 토큰을 삭제 → 새 게스트 토큰 발급 → 다른 sessionId
- `VillageScene.myDisplayId` 는 씬 create 시 1회만 결정 → stale 한 채로 자기 broadcast 를 "남"으로 인식 → 본인 옆에 분신 등장
- 콜드 스타트가 직접 원인이 아니라 **localStorage 의 만료 토큰을 그대로 보내는 흐름** 이 본질. 운영 로그에 `Invalid or expired token` 확인.

## Changes

### Frontend fix (commit `5cb01dc`)

| Fix | 동작 |
|-----|------|
| **3-A** 토큰 만료 사전 체크 | `useStomp` 가 `connect` 전 `isTokenExpired(exp+60s 마진)` 검사. 만료/임박 시 미리 갱신 → STOMP 가 만료 토큰을 보내는 트리거 자체 차단 |
| **3-B** `onError` 메시지 분기 | `headers.message === 'Invalid or expired token'` 일 때만 토큰 갱신, 그 외(네트워크·timeout)는 토큰 재사용. 무한 루프 방어 카운터 |
| **3-C** `tokenBridge` + myDisplayId 동기화 | `positionBridge` 패턴 차용. `useStomp` 가 토큰 결정 시점에 `emitDisplayIdChange`, `VillageScene` 이 구독해 자기인식 깨짐 자체를 방어 |
| **3-D** `beforeunload` graceful disconnect (보조) | 탭 종료 시 `STOMP deactivate` → SockJS heartbeat timeout 까지 기다리지 않고 LEAVE 즉시 발송. 운영 검증 후 효과 없으면 부분 revert 가능 |

### Backend 보조 (commit `ed40c7f`)

- `jwt.guest-token-expiry-ms: 86400000` (24h) — 게스트 토큰을 멤버(1h)와 분리. 게스트는 권한 거의 없음(마을 위치/공개 채팅), 24h 가 보안적 무리 없음
- 3-A 사전 체크와 함께 작용해 만료 토큰 재발급 빈도를 거의 0 으로

### Docs (commit `d7d1083`)

- `learning/54` 신규 — 진단 노트 (의심한 영역 vs 진짜 원인, 7단계 추적, 시야 확장)
- `learning/INDEX`·`RESERVED` 갱신 — 54 사용 완료, 55·57·58 반환
- `track-ghost-session.md` — Step 2 의제를 fix 방향 합의로 재정의, 다중 세션 정책 범위 외 명시

## Verification

- [x] `npm run lint` 통과
- [x] `npm run build` 통과 (Next.js 16.2.2)
- [x] `npm run test:run` — 4 파일, 21 tests passed (신규 16: auth 12, tokenBridge 3, 회귀 0)
- [x] Backend `./gradlew compileJava compileTestJava` — 컴파일 에러 없음
- [x] Backend JWT 관련 테스트 — BUILD SUCCESSFUL

## Test Plan (운영 배포 후)

- [ ] 만료 토큰을 가진 클라이언트로 진입해 자기 분신이 나타나지 않는지 확인 (시나리오 나)
- [ ] 탭 강제 종료 시 다른 클라이언트 화면에서 캐릭터 사라지는 시간 측정 (시나리오 가, 3-D 효과 검증)
- [ ] 3-D 가 LEAVE 도달 시간 단축에 실효 없으면 별도 commit 으로 revert
- [ ] 운영 로그에서 `Invalid or expired token` 발생 빈도 추적 — 거의 0 이어야 함

## Out of Scope

**동일 `userId` 다중 세션 정책 (대체/거부/병행)** — #28 의 직접 원인 아님이 진단으로 확정. 멀티 디바이스/멀티 탭 시나리오는 별도 이슈로 분리 예정 (`learning/54` 마지막 섹션 참조).

## Related

- Issue: Closes #28
- Track: [`docs/handover/track-ghost-session.md`](./docs/handover/track-ghost-session.md)
- Diagnosis: [`docs/learning/54-presence-cleanup-ghost-character-diagnosis.md`](./docs/learning/54-presence-cleanup-ghost-character-diagnosis.md)