### PR TITLE
[village-design-mvp] Welcome 메시지 브랜드명 ghworld 변경

### DIFF
--- a/frontend/src/components/ui/WelcomeOverlay.tsx
+++ b/frontend/src/components/ui/WelcomeOverlay.tsx
@@ -48,7 +48,7 @@ export default function WelcomeOverlay() {
           className="font-display text-2xl"
           style={{ color: 'var(--color-bark)', letterSpacing: '0.02em' }}
         >
-          마음의 고향에 오신 것을 환영합니다
+          ghworld에 오신 것을 환영합니다
         </p>
         <p
           className="mt-3 text-sm"


### PR DESCRIPTION
## Summary

마을 입장 Welcome 화면의 메인 메시지 브랜드명을 도메인(ghworld.co) 와 일치하도록 변경.

## 변경

| 위치 | Before | After |
|------|--------|-------|
| `frontend/src/components/ui/WelcomeOverlay.tsx` 메인 메시지 | "마음의 고향에 오신 것을 환영합니다" | **"ghworld에 오신 것을 환영합니다"** |
| 서브 메시지 | "말 안 해도 괜찮아요. 천천히 머무세요." | (그대로) |

## 짚을 것 — 다른 곳 표기는 유지

본 PR 은 **Welcome 화면만** 변경. CLAUDE.md §2 / 다른 UI / 문서의 "마음의 고향" 표기는 유지.

전체 브랜드명 통일 의도 시 별도 chore PR 또는 트랙으로 처리 (현재 트랙 스코프 밖).

## 운영 영향

- base = `feat/village-design-mvp` (통합 브랜치)
- main 영향 0 (D9 정책)
- 트랙 종료 시 통합 → main 머지 시점에 일괄 운영 반영

## 트랙 컨텍스트

- 트랙: `village-design-mvp` (Issue #56)
- 이전 PR: #57 (Step 1 — Welcome 모션 도입 직후 브랜드명 정정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)