### PR TITLE
chore(coderabbit): village-design-mvp 통합 브랜치를 auto_review base 에 추가

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,6 +16,9 @@ reviews:
     drafts: false
     base_branches:
       - main
+      # 트랙 통합 브랜치 (long-lived, D9 정책 — docs/specs/features/village-design-mvp.md)
+      # 트랙 종료 시 본 항목 제거. 새 트랙 통합 브랜치 추가 시 1줄 추가.
+      - feat/village-design-mvp
     ignore_title_keywords:
       - "WIP"
       - "DO NOT MERGE"


### PR DESCRIPTION
## Summary

CodeRabbit 가 main 의 `.coderabbit.yaml` 만 본다는 정책상, base 가 통합 브랜치인 step PR 들이 자동 리뷰 skip 됨 (PR #57 에서 "Review skipped" 발생). 본 PR 로 통합 브랜치도 auto_review base 에 추가하여 다음 step PR 부터 자동 리뷰 작동.

## 변경

```diff
auto_review:
   enabled: true
   drafts: false
   base_branches:
     - main
+    # 트랙 통합 브랜치 (long-lived, D9 정책)
+    - feat/village-design-mvp
```

## 배경 — D9 정책의 부작용

`docs/specs/features/village-design-mvp.md` D9 (트랙 통합 PR 흐름) 도입 후, step PR 들이 base=통합 브랜치 로 향함. CodeRabbit 자동 리뷰가 default branch 기준만 작동해서 모든 step PR 이 skip.

## 운영 정책 (.coderabbit.yaml 코멘트로 명시)

- 트랙 종료 (통합 → main 일괄 머지) 시점에 본 항목 제거
- 새 트랙 통합 브랜치 시작 시 1줄 추가

## 영향 범위

- CodeRabbit 자동 리뷰 trigger 영역만 변경
- 코드/빌드/배포 영향 0
- `deploy.yml` paths-ignore 와 무관 (CD trigger 발화 가능성 있으나 빌드 산출물 변경 없음)

## 트랙 컨텍스트

- 관련 트랙: `village-design-mvp` (Issue #56)
- 관련 PR: #57 (Step 1 — Review skipped 발생 PR)
- 관련 spec: `docs/specs/features/village-design-mvp.md` D9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * 코드 리뷰 설정에 새로운 기본 브랜치 경로를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->