### PR TITLE
fix(chat): ChatOverlay 너비 큰 모니터 결 박음 (700/1200/360)

### DIFF
--- a/frontend/src/components/chat/ChatOverlay.tsx
+++ b/frontend/src/components/chat/ChatOverlay.tsx
@@ -11,7 +11,10 @@ import ChatMessageList from './ChatMessageList';
 import LoginPrompt from './LoginPrompt';
 
 const CHAT_HEIGHT = { min: 100, max: 600, initial: 240 };
-const CHAT_WIDTH = { min: 300, max: 800, initial: 400 };
+// 큰 모니터(4K~5K) 에서 width 400 은 화면 비율 7~10% → 사용자 인지 어려움.
+// initial 700 + max 1200 으로 늘려 큰 화면에서도 채팅창이 한눈에 보이게 한다.
+// 드래그로 사용자가 자기 모니터에 맞게 추가 조정 가능 (useResize).
+const CHAT_WIDTH = { min: 360, max: 1200, initial: 700 };
 
 export default function ChatOverlay() {
   const inputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
## Summary

큰 모니터(4K~5K) 에서 ChatOverlay 너비가 화면 대비 너무 좁아 인지 어려움 → 기본/최대 결 키움.

| 항목 | 변경 전 | 변경 후 | 결 |
|---|---|---|---|
| `min` | 300 | **360** | 작은 화면 결 안정 |
| `initial` | 400 | **700** | 큰 모니터에서 한눈에 보임 |
| `max` | 800 | **1200** | 4K~5K 결 가용 폭 |

드래그 결로 사용자가 자기 모니터에 맞게 추가 조정 가능 (`useResize`).

## 배경 (별도 PR 결로 분리한 이유)

본 핫픽스는 `village-design-mvp` Step 2 (Cozy Pack 시안) 작업 중 발견된 결인데, 트랙 결정 변경 (Phaser 2D → Three.js 3D) 결로 트랙 종료됨 (PR #65 머지). 핫픽스 자체는 마을 결과 무관한 작은 UX 결이라 종료 PR 결과 분리해서 별도 작은 PR 결로 박음.

## Test plan

- [x] `frontend/src/components/chat/ChatOverlay.tsx` 1 파일만 변경 (`CHAT_WIDTH` 상수 + 주석)
- [ ] 4K 모니터 결 결 확인 — 채팅창 한눈에 보이는 결
- [ ] FHD (1920x1080) 결 결 확인 — 너무 크지 않은 결
- [ ] 작은 창 (min) 결 결 확인 — 360 결 안정

## 참조

- 트랙 종료 PR [#65](https://github.com/zkzkzhzj/ChatAppProject/pull/65) (별도)
- learning [72](docs/learning/72-phaser-to-threejs-pivot-decision.md) §흔들림 사이클

🤖 Generated with [Claude Code](https://claude.com/claude-code)