### PR TITLE
fix(deps): react-dom 19.2.4 → 19.2.5 — Dependabot 회귀 핫픽스

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,7 @@
         "next": "16.2.2",
         "phaser": "^3.90.0",
         "react": "19.2.5",
-        "react-dom": "19.2.4",
+        "react-dom": "19.2.5",
         "sockjs-client": "^1.6.1",
         "zustand": "^5.0.12"
       },
@@ -6887,15 +6887,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "next": "16.2.2",
     "phaser": "^3.90.0",
     "react": "19.2.5",
-    "react-dom": "19.2.4",
+    "react-dom": "19.2.5",
     "sockjs-client": "^1.6.1",
     "zustand": "^5.0.12"
   },


### PR DESCRIPTION
## 문제

PR #54 (Dependabot)가 `react`만 19.2.5로 올리고 `react-dom`은 19.2.4로 남겨 React mismatch 발생. dev 띄우면 SSR 깨지면서 다음 에러:

\`\`\`
Error: Incompatible React versions: The "react" and "react-dom" packages must have the exact same version.
  - react:      19.2.5
  - react-dom:  19.2.4
\`\`\`

## 수정

`package.json`의 `react-dom`을 19.2.5로 동기화 + `npm install`로 lockfile 갱신.

| 파일 | 변경 |
|---|---|
| `frontend/package.json` | `"react-dom": "19.2.4"` → `"19.2.5"` |
| `frontend/package-lock.json` | npm install로 자동 갱신 |

## main 직접 머지 사유

모든 트랙(`village-3d` 등)에 영향 주는 회귀. 통합 브랜치 우회하면 트랙 머지 전까지 dev/build 깨진 상태 유지됨.

## 검증
- [x] `npm run lint` ✅
- [x] `npm run build` ✅
- [x] 사용자 보고 회귀 (`npm run dev` → React 호환성 에러 → 화면 안 뜸)

## 관련
- PR #54 — Dependabot 회귀 발생 commit (`react` only 업데이트)
- Issue [#67](https://github.com/zkzkzhzj/ChatAppProject/issues/67) — village-3d 트랙 (영향 받음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * React DOM 라이브러리를 최신 패치 버전으로 업데이트했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkzkzhzj/ChatAppProject/pull/70)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->