### PR TITLE
fix(deps): react 19.2.5 → 19.2.6 — Dependabot #73 peer 충돌 핫픽스

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "axios": "1.14.0",
         "next": "16.2.6",
         "phaser": "^3.90.0",
-        "react": "19.2.5",
+        "react": "19.2.6",
         "react-dom": "19.2.6",
         "sockjs-client": "^1.6.1",
         "zustand": "^5.0.12"
@@ -6892,9 +6892,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
-      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "axios": "1.14.0",
     "next": "16.2.6",
     "phaser": "^3.90.0",
-    "react": "19.2.5",
+    "react": "19.2.6",
     "react-dom": "19.2.6",
     "sockjs-client": "^1.6.1",
     "zustand": "^5.0.12"


### PR DESCRIPTION
## 사건

Dependabot PR #73 (react-dom 19.2.5 → 19.2.6) 머지 후 main CI Frontend job 깨짐:

```
peer react@"^19.2.6" from react-dom@19.2.6
Found: react@19.2.5
```

react-dom 만 올리고 react 는 19.2.5 에 남아 ERESOLVE.

## 회귀 패턴

옛 PR #70 (`fix/react-version-mismatch`) 결박 같은 케이스. Dependabot 이 한 쪽만 올리는 회귀. react/react-dom 은 항상 같은 버전으로 묶어야 함.

## 수정

`frontend/package.json` react 19.2.5 → 19.2.6 + lock 갱신.

## 검증

- npm install 통과 (ERESOLVE 해소)
- (CI 결박 자동 재실행 결박 결박 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)