### PR TITLE
fix(harden-village-ops): Step 1 — UserRegisteredEventConsumer idempotency marker release + 회귀 테스트

### DIFF
--- a/backend/src/main/java/com/maeum/gohyang/village/adapter/in/messaging/UserRegisteredEventConsumer.java
+++ b/backend/src/main/java/com/maeum/gohyang/village/adapter/in/messaging/UserRegisteredEventConsumer.java
@@ -43,8 +43,9 @@ public class UserRegisteredEventConsumer {
     @Transactional
     public void handle(ConsumerRecord<String, String> record) {
         log.debug("user.registered 수신: key={}", record.key());
+        UUID idempotencyKey = null;
         try {
-            UUID idempotencyKey = KafkaEventIdExtractor.extract(record);
+            idempotencyKey = KafkaEventIdExtractor.extract(record);
             if (!idempotencyGuard.tryAcquire(idempotencyKey)) {
                 log.debug("중복 이벤트 무시: eventId={}", idempotencyKey);
                 return;
@@ -58,6 +59,11 @@ public class UserRegisteredEventConsumer {
             long userId = userIdNode.asLong();
             initializeUserVillageUseCase.execute(userId);
         } catch (Exception e) {
+            // 처리 실패 시 멱등성 마킹 해제 → Kafka 재시도 허용
+            // ConversationSummaryEventConsumer:103-107 동일 패턴
+            if (idempotencyKey != null) {
+                idempotencyGuard.release(idempotencyKey);
+            }
             alertPort.critical(
                     AlertContext.of("village-consumer", record.key(), record.key()),
                     "user.registered 처리 실패: " + e.getMessage()

--- a/backend/src/main/java/com/maeum/gohyang/village/adapter/in/messaging/UserRegisteredEventConsumer.java
+++ b/backend/src/main/java/com/maeum/gohyang/village/adapter/in/messaging/UserRegisteredEventConsumer.java
@@ -44,12 +44,17 @@ public class UserRegisteredEventConsumer {
     public void handle(ConsumerRecord<String, String> record) {
         log.debug("user.registered 수신: key={}", record.key());
         UUID idempotencyKey = null;
+        boolean acquired = false;
         try {
             idempotencyKey = KafkaEventIdExtractor.extract(record);
             if (!idempotencyGuard.tryAcquire(idempotencyKey)) {
                 log.debug("중복 이벤트 무시: eventId={}", idempotencyKey);
                 return;
             }
+            // 본 consumer 가 tryAcquire true 반환을 직접 받은 경우에만 acquired = true.
+            // 이 가드 없이 catch 결박 release 하면 — tryAcquire 자체 예외 (DB pool 고갈 등) 시
+            // 이미 다른 consumer instance 가 박은 marker 까지 삭제할 위험 (Codex P1, PR #95).
+            acquired = true;
             JsonNode root = objectMapper.readTree(record.value());
             JsonNode userIdNode = root.get("userId");
             if (userIdNode == null || userIdNode.isNull()) {
@@ -59,9 +64,9 @@ public class UserRegisteredEventConsumer {
             long userId = userIdNode.asLong();
             initializeUserVillageUseCase.execute(userId);
         } catch (Exception e) {
-            // 처리 실패 시 멱등성 마킹 해제 → Kafka 재시도 허용
-            // ConversationSummaryEventConsumer:103-107 동일 패턴
-            if (idempotencyKey != null) {
+            // 본 consumer 가 직접 acquire 한 marker 만 release.
+            // ConversationSummaryEventConsumer:103-107 의 idempotencyKey != null 패턴 보다 안전.
+            if (acquired) {
                 idempotencyGuard.release(idempotencyKey);
             }
             alertPort.critical(

--- a/backend/src/test/java/com/maeum/gohyang/village/adapter/in/messaging/UserRegisteredEventConsumerTest.java
+++ b/backend/src/test/java/com/maeum/gohyang/village/adapter/in/messaging/UserRegisteredEventConsumerTest.java
@@ -1,0 +1,132 @@
+package com.maeum.gohyang.village.adapter.in.messaging;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.maeum.gohyang.global.alert.AlertPort;
+import com.maeum.gohyang.global.infra.idempotency.IdempotencyGuard;
+import com.maeum.gohyang.village.application.port.in.InitializeUserVillageUseCase;
+
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * UserRegisteredEventConsumer 회귀 방지 테스트 (트랙 harden-village-ops Step 1).
+ *
+ * 핵심 검증 (PR #91 full-review-agent R1):
+ *   execute() 예외 시 idempotency marker leak 차단 — catch 블록에서
+ *   IdempotencyGuard.release() 호출되는지 보장.
+ *
+ * 이전 코드 (release 누락) 결박 Kafka 재배달 시 marker 잔존 → 비즈니스 로직 영구 스킵
+ * → character/space 미생성 → 첫 로그인 500.
+ *
+ * 패턴 출처: ConversationSummaryEventConsumer:103-107.
+ */
+@ExtendWith(MockitoExtension.class)
+class UserRegisteredEventConsumerTest {
+
+    @Mock
+    private InitializeUserVillageUseCase initializeUserVillageUseCase;
+
+    @Mock
+    private IdempotencyGuard idempotencyGuard;
+
+    @Mock
+    private AlertPort alertPort;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private UserRegisteredEventConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        consumer = new UserRegisteredEventConsumer(
+                initializeUserVillageUseCase,
+                idempotencyGuard,
+                alertPort,
+                objectMapper);
+    }
+
+    /**
+     * Header 없이 record 생성 — KafkaEventIdExtractor 가 fallback (key + offset 기반 UUID) 사용.
+     */
+    private ConsumerRecord<String, String> userRegisteredRecord(String key, String body) {
+        return new ConsumerRecord<>("user.registered", 0, 0L, key, body);
+    }
+
+    @Test
+    @DisplayName("execute() 예외 시 idempotency marker release 호출 → Kafka 재배달 허용")
+    void execute_예외_시_release_호출() {
+        // given
+        ConsumerRecord<String, String> record = userRegisteredRecord("user-1", "{\"userId\":1}");
+        when(idempotencyGuard.tryAcquire(any(UUID.class))).thenReturn(true);
+        doThrow(new RuntimeException("DB 일시 장애"))
+                .when(initializeUserVillageUseCase).execute(1L);
+
+        // when + then
+        assertThatThrownBy(() -> consumer.handle(record))
+                .isInstanceOf(RuntimeException.class);
+
+        verify(idempotencyGuard, times(1)).release(any(UUID.class));
+        verify(alertPort, times(1)).critical(any(), any());
+    }
+
+    @Test
+    @DisplayName("정상 처리 시 release 호출 안 함 — marker 보존 결박 재배달 차단")
+    void 정상_처리_시_release_호출_안_함() {
+        // given
+        ConsumerRecord<String, String> record = userRegisteredRecord("user-1", "{\"userId\":1}");
+        when(idempotencyGuard.tryAcquire(any(UUID.class))).thenReturn(true);
+
+        // when
+        consumer.handle(record);
+
+        // then
+        verify(initializeUserVillageUseCase, times(1)).execute(1L);
+        verify(idempotencyGuard, never()).release(any());
+    }
+
+    @Test
+    @DisplayName("중복 이벤트 (tryAcquire false) 시 execute / release 모두 호출 안 함")
+    void 중복_이벤트_시_스킵() {
+        // given
+        ConsumerRecord<String, String> record = userRegisteredRecord("user-1", "{\"userId\":1}");
+        when(idempotencyGuard.tryAcquire(any(UUID.class))).thenReturn(false);
+
+        // when
+        consumer.handle(record);
+
+        // then
+        verify(initializeUserVillageUseCase, never()).execute(any(Long.class));
+        verify(idempotencyGuard, never()).release(any());
+    }
+
+    @Test
+    @DisplayName("JSON 파싱 실패 시 release 호출 — marker INSERT 후 비즈니스 진입 전 예외")
+    void JSON_파싱_실패_시_release_호출() {
+        // given
+        ConsumerRecord<String, String> record = userRegisteredRecord("user-1", "{invalid json}");
+        when(idempotencyGuard.tryAcquire(any(UUID.class))).thenReturn(true);
+
+        // when + then
+        assertThatThrownBy(() -> consumer.handle(record))
+                .isInstanceOf(Exception.class);
+
+        verify(idempotencyGuard, times(1)).release(any(UUID.class));
+        verify(initializeUserVillageUseCase, never()).execute(any(Long.class));
+    }
+}

--- a/backend/src/test/java/com/maeum/gohyang/village/adapter/in/messaging/UserRegisteredEventConsumerTest.java
+++ b/backend/src/test/java/com/maeum/gohyang/village/adapter/in/messaging/UserRegisteredEventConsumerTest.java
@@ -129,4 +129,21 @@ class UserRegisteredEventConsumerTest {
         verify(idempotencyGuard, times(1)).release(any(UUID.class));
         verify(initializeUserVillageUseCase, never()).execute(any(Long.class));
     }
+
+    @Test
+    @DisplayName("tryAcquire 자체 예외 시 release 호출 안 함 — 다른 consumer 의 marker 보호 (Codex P1)")
+    void tryAcquire_자체_예외_시_release_호출_안_함() {
+        // given — tryAcquire 가 DB pool 고갈 등으로 throw. 본 consumer 는 marker acquire X.
+        ConsumerRecord<String, String> record = userRegisteredRecord("user-1", "{\"userId\":1}");
+        when(idempotencyGuard.tryAcquire(any(UUID.class)))
+                .thenThrow(new RuntimeException("DB connection pool exhausted"));
+
+        // when + then
+        assertThatThrownBy(() -> consumer.handle(record))
+                .isInstanceOf(RuntimeException.class);
+
+        // release 호출 X — 이미 다른 consumer 가 박은 marker 를 삭제하면 안 됨
+        verify(idempotencyGuard, never()).release(any());
+        verify(initializeUserVillageUseCase, never()).execute(any(Long.class));
+    }
 }

--- a/docs/handover/INDEX.md
+++ b/docs/handover/INDEX.md
@@ -12,9 +12,9 @@
 
 | 트랙 ID | 파일 | 작업 영역 | 상태 | 이슈 | 시작일 |
 |---------|------|-----------|------|------|--------|
+| `harden-village-ops` | [track-harden-village-ops.md](./track-harden-village-ops.md) | 백엔드 운영 P1 — UserRegisteredEventConsumer release + JWT_SECRET 폴백 제거 + 동시성 unit test | 🔧 Step 1 진행 (release + 테스트 박힘, PR #95) | #92 | 2026-05-17 |
 
-> 활성 트랙 없음 (2026-05-17 기준, 트랙 `ai-native-2026-05-upgrade` 종료 직후).
-> 보류: ⓑ `harden-village-ops` (Issue #92, branch `fix/harden-village-ops`, commit `a99e4cc`) — origin 보존, 사용자 재개 결정 대기.
+> PR #94 (트랙 ⓒ ai-native-2026-05-upgrade) 머지 직후 트랙 ⓑ `harden-village-ops` 활성. Step 1 (UserRegisteredEventConsumer release + 회귀 테스트 + Codex P1 acquired flag) 진행 중.
 > Planned: skills-progressive-disclosure (Step 4·5) / anthropic-outcomes-trial (Step 6) / npc-evaluator-lmops 보강 (sweep v2 §B·§E).
 > ws-redis Step 3 도 후보. `track-ws-redis.md` §9 인수인계 참조.
 
@@ -42,10 +42,9 @@
 
 | 트랙 ID | 예상 작업 영역 | 메모 |
 |---------|---------------|------|
-| `harden-village-ops` | 운영 P1 두 개 — UserRegisteredEventConsumer release + JWT_SECRET 폴백 제거 + 동시성 unit test + JaCoCo 0.50 복원 | **보류 (2026-05-17)** — Issue #92, branch `fix/harden-village-ops`, Step 0 commit `a99e4cc` (origin 보존). 사용자 의도 ⓒ 우선 진행 후 재개 결정. learning 80~82 예약. |
 | `skills-progressive-disclosure` | track-start / track-end SKILL.md supporting files 분리 + `/discover-domain-patterns` 자체 슬래시 스킬 (Agent OS 패턴 차용) | 트랙 ⓒ Step 4·5 분리 산출. sweep v1 §C.4·§B.5 + learning 83 D4 출처. 후속 — spec-new / step-start 마이그 Phase 2. |
-| `anthropic-outcomes-trial` | Anthropic Outcomes public beta 시범 — 우리 spec verification 결박 자동 grader 결합 가능성 | 트랙 ⓒ Step 6 분리 산출. sweep v2 §D.2 출처. |
-| `npc-evaluator-lmops` 보강 | Langfuse self-host + OpenLIT + Grafana Anthropic prebuilt (sweep v2 §B·§E) | 사전 ADR learning 68 결박 보강. sweep v2 결박 결박 결박 결박. |
+| `anthropic-outcomes-trial` | Anthropic Outcomes public beta 시범 — 우리 spec verification 과 자동 grader 결합 가능성 | 트랙 ⓒ Step 6 분리 산출. sweep v2 §D.2 출처. |
+| `npc-evaluator-lmops` 보강 | Langfuse self-host + OpenLIT + Grafana Anthropic prebuilt (sweep v2 §B·§E) | 사전 ADR learning 68 의 보강. sweep v2 결과 매트릭스 직접 반영. |
 | `token-auto-renewal` | Issue #38 — refresh token + rotation, HttpOnly cookie 발급, WS 토큰 갱신, 게스트 영속 식별자 | 수행계획서·결정 게이트 통과·구현계획서 [track-token-auto-renewal.md](./track-token-auto-renewal.md) 에 보존. **2026-05-02 재차 보류** — Redis 저장소 선택의 5패턴 비교 + 블로그 포스팅까지 깊이 있게 가져갈 주제로 판단, UI 디자인 트랙 우선 처리 후 재개 |
 | `s3-media` | S3 도입 (집 배경 이미지, 캐릭터 등) | 사전 결정 필요: 무엇을 올릴지 / 비용 정책 / 유해 필터 |
 

--- a/docs/handover/track-harden-village-ops.md
+++ b/docs/handover/track-harden-village-ops.md
@@ -1,8 +1,8 @@
 # Track: harden-village-ops
 
 > 작업 영역: 백엔드 운영 P1 — `UserRegisteredEventConsumer` idempotency release + `JWT_SECRET` 폴백 제거
-> 시작일: TBD (트랙 시작 시 본 줄 갱신)
-> Issue: #TBD (gh issue create + label `track:harden-village-ops`)
+> 시작일: 2026-05-17
+> Issue: #92 (gh issue create + label `track:harden-village-ops`)
 > 브랜치: `fix/harden-village-ops` (main 기준 분기)
 > Spec: [docs/specs/features/harden-village-ops.md](../specs/features/harden-village-ops.md)
 > 사전 ADR: PR #91 `full-review-agent` 결과 (운영 리스크 Top 5 R1·R2·R3)
@@ -36,16 +36,16 @@ PR #91 (`ctx-refresh-post-village-3d`) 의 `full-review-agent` 가 잡은 운영
 
 | Step | 내용 | 의존 | 상태 | 이슈 | PR |
 |------|------|------|------|------|-----|
-| 1 | UserRegisteredEventConsumer.release + Kafka 재배달 시나리오 테스트 | — | 대기 | #TBD | — |
-| 2 | JWT_SECRET 폴백 제거 + ConfigurationProperties Validated NotBlank Size(min=64) | step1 | 대기 | #TBD | — |
-| 3 | identity/village 동시성 unit test + JaCoCo 0.40→0.50 복원 | step1 | 대기 | #TBD | — |
+| 1 | UserRegisteredEventConsumer.release + Kafka 재배달 시나리오 테스트 | — | 대기 | #92 | — |
+| 2 | JWT_SECRET 폴백 제거 + ConfigurationProperties Validated NotBlank Size(min=64) | step1 | 대기 | #92 | — |
+| 3 | identity/village 동시성 unit test + JaCoCo 0.40→0.50 복원 | step1 | 대기 | #92 | — |
 
 ## 3. 현재 단계 상세
 
 **트랙 미시작** — PR #91 머지 후 시작 권장. `/track-start harden-village-ops` 또는 수동:
 
 1. `gh label create track:harden-village-ops` + `gh issue create`
-2. `docs/handover/INDEX.md` 활성 표 1행 추가 (#TBD → 발급된 #N)
+2. `docs/handover/INDEX.md` 활성 표 1행 추가 (#92 → 발급된 #N)
 3. `docs/learning/RESERVED.md` 80~82 예약 (이미 pre-scaffold 됨)
 4. `git checkout -b fix/harden-village-ops origin/main` (PR #91 머지 후 main 기준)
 5. Step 1 진입

--- a/docs/specs/features/harden-village-ops.md
+++ b/docs/specs/features/harden-village-ops.md
@@ -1,7 +1,7 @@
 ---
 feature: harden-village-ops
 track: harden-village-ops
-issue: "#TBD (트랙 시작 시 gh issue create)"
+issue: "#92 (트랙 시작 시 gh issue create)"
 status: draft
 created: 2026-05-17
 last-updated: 2026-05-17
@@ -78,9 +78,9 @@ last-updated: 2026-05-17
 
 | Step | 내용 | 의존 | 예상 변경 영역 | 이슈 | PR |
 |------|------|------|---------------|------|-----|
-| 1 | `UserRegisteredEventConsumer.handle` catch 블록 `idempotencyGuard.release()` 추가 + Cucumber/unit 시나리오 (Kafka 재배달) | — | `backend/.../village/adapter/in/messaging/UserRegisteredEventConsumer.java` + test | #TBD | TBD |
-| 2 | JWT_SECRET 폴백 제거 — `application.yml` + `docker-compose.yml` + `@ConfigurationProperties` + `@Validated` `@NotBlank` `@Size(min=64)` | step1 | `backend/src/main/resources/application.yml`, `deploy/docker-compose.yml`, `backend/.../global/security/JwtProperties.java` | #TBD | TBD |
-| 3 | 회원가입 동시성 unit test (`RegisterUserServiceConcurrencyTest` + `InitializeUserVillageServiceConcurrencyTest`) + JaCoCo 0.40 → 0.50 복원 검증 | step1 | `backend/src/test/java/.../identity/` + `backend/src/test/java/.../village/` + `backend/build.gradle.kts` | #TBD | TBD |
+| 1 | `UserRegisteredEventConsumer.handle` catch 블록 `idempotencyGuard.release()` 추가 + Cucumber/unit 시나리오 (Kafka 재배달) | — | `backend/.../village/adapter/in/messaging/UserRegisteredEventConsumer.java` + test | #92 | TBD |
+| 2 | JWT_SECRET 폴백 제거 — `application.yml` + `docker-compose.yml` + `@ConfigurationProperties` + `@Validated` `@NotBlank` `@Size(min=64)` | step1 | `backend/src/main/resources/application.yml`, `deploy/docker-compose.yml`, `backend/.../global/security/JwtProperties.java` | #92 | TBD |
+| 3 | 회원가입 동시성 unit test (`RegisterUserServiceConcurrencyTest` + `InitializeUserVillageServiceConcurrencyTest`) + JaCoCo 0.40 → 0.50 복원 검증 | step1 | `backend/src/test/java/.../identity/` + `backend/src/test/java/.../village/` + `backend/build.gradle.kts` | #92 | TBD |
 
 ## 6. Verification
 


### PR DESCRIPTION
## Summary

PR #91 (트랙 ⓐ ctx-refresh) 의 `full-review-agent` 가 발견한 **운영 리스크 Top 5 의 R1 (P1)** 처치.

- Issue: Refs #92 (Closes 결박 X — Step 2·3 진행 후 close)
- Spec: [docs/specs/features/harden-village-ops.md](https://github.com/zkzkzhzj/ChatAppProject/blob/fix/harden-village-ops/docs/specs/features/harden-village-ops.md)
- Track: [docs/handover/track-harden-village-ops.md](https://github.com/zkzkzhzj/ChatAppProject/blob/fix/harden-village-ops/docs/handover/track-harden-village-ops.md)

## 원인 — idempotency marker leak

```text
[현재 코드 (leak)]
첫 이벤트:
  ① tryAcquire → marker INSERT (@Transactional REQUIRES_NEW = 독립 commit)
  ② JSON 파싱 / execute() **예외** → throw e
     ※ marker 는 ①에서 이미 commit 됐으므로 잔존
  ③ Kafka 재배달:
     ① tryAcquire → marker 이미 존재 → false → 비즈니스 로직 영구 스킵
  → character + space 미생성 → 첫 로그인 500

[Fix]
catch 블록 결박 idempotencyGuard.release(key) 호출 추가
→ marker DELETE → 재배달 시 tryAcquire true → 정상 처리
```

대조군 = `ConversationSummaryEventConsumer:103-107` 결박 동일 패턴 결박 release 호출 박혀있음. village consumer 만 누락. 본 PR 결박 동일 패턴 복사.

## 변경 (2 파일)

| 파일 | 변경 |
|---|---|
| `UserRegisteredEventConsumer.java` | idempotencyKey try 밖 선언 + catch 결박 `if (key != null) release(key)` 호출 추가 (5줄 변경) |
| `UserRegisteredEventConsumerTest.java` (신규) | Mockito 결박 회귀 방지 테스트 4개 |

## 테스트 4개

1. **`execute_예외_시_release_호출`** — 핵심 회귀 방지. execute() 예외 → release 1회 + alert 1회 + throw
2. **`정상_처리_시_release_호출_안_함`** — marker 보존 결박 재배달 차단
3. **`중복_이벤트_시_스킵`** — tryAcquire false → execute 0회 + release 0회
4. **`JSON_파싱_실패_시_release_호출`** — marker INSERT 후 비즈니스 진입 전 예외

## 검증

- 로컬 `./gradlew test` BUILD SUCCESSFUL (1m 54s, 신규 4 + 기존 모두 pass)

## Acceptance Criteria 진행 (트랙 spec §6)

- [x] **Step 1**: UserRegisteredEventConsumer.release + 회귀 테스트 (본 PR)
- [ ] Step 2: JWT_SECRET 폴백 제거 (application.yml + docker-compose.yml + @Validated @NotBlank @Size(min=64))
- [ ] Step 3: identity/village 동시성 unit test 추가 + JaCoCo 0.40 → 0.50 복원

본 PR 머지 후 Step 2 진행 (사용자 결정).

## PR #94 (트랙 ⓒ) 와의 관계

본 PR 과 PR #94 는 **base = origin/main 동일, 독립 PR**. 두 PR 모두 머지 시 `docs/handover/INDEX.md` 결박 1줄 충돌 가능 — 후순위 머지 PR 결박 rebase 결박 충돌 해결 (1줄).

## Test plan

- [x] 로컬 `./gradlew test` pass
- [ ] CI backend pass 대기
- [ ] CI markdown lint pass 대기
- [ ] CodeRabbit / Codex 자동 리뷰

Refs #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)