### PR TITLE
infra(s3-media): Step 1 — S3 버킷 + Bucket Policy + CORS + ADR 009

### DIFF
--- a/docs/architecture/decisions/009-s3-asset-hosting.md
+++ b/docs/architecture/decisions/009-s3-asset-hosting.md
@@ -1,0 +1,174 @@
+# ADR 009 — 정적 에셋 외부 호스팅 (AWS S3 + versioned prefix)
+
+> **상태**: Accepted
+> **결정일**: 2026-05-17
+> **트랙**: [`s3-media`](../../handover/track-s3-media.md) (Issue #89)
+> **spec**: [`docs/specs/features/s3-media.md`](../../specs/features/s3-media.md)
+> **관련 learning**: 51 (R2 vs S3 ADR — 작성 예정), 52 (frontend 자산 외부화 패턴 — 작성 예정)
+
+## 컨텍스트
+
+운영 환경(`ghworld.co`)에서 환경음 4종 + BGM 무음 상태. 원인:
+
+- `frontend/.gitignore:44-50` 결로 mp3 추적 X (spec D4' "외부 인프라 마이그 예정" 결로 미뤄둠)
+- Docker 이미지 빌드 컨텍스트에 mp3 미포함 → 컨테이너 재시작/재배포 시마다 무음
+- 사용자가 BGM mp3를 EC2에 SCP로 직접 올렸으나, 새 이미지 배포 시 사라짐
+
+도서관 트랙에서 자산이 더 늘어날 예정 (3D 인테리어·NPC 음성·채팅 이미지). 지금 git에 묶었다가 빼는 두 번 일 피하기 위해 정석으로 외부화.
+
+## 결정
+
+**AWS S3 단일 버킷 + versioned prefix 패턴**으로 정적 에셋을 외부 호스팅한다.
+
+### 핵심 결정 3축
+
+1. **스토리지 = AWS S3** (Cloudflare R2 X) — spec D1
+2. **도메인 = raw S3 URL** (CloudFront 후속) — spec D2
+3. **폴더 = versioned prefix** (`v1/`) — spec D5
+
+### 인프라 사양
+
+| 항목 | 값 |
+|---|---|
+| 버킷 이름 | `gohyang-s3-buket-20260514` |
+| 리전 | `ap-northeast-2` (서울) |
+| URL 형식 | `https://gohyang-s3-buket-20260514.s3.ap-northeast-2.amazonaws.com/v1/{path}` |
+| 정적 prefix | `v1/audio/{ambient,bgm}/`, `v1/models/`, `v1/textures/` (확장 예정) |
+| 사용자 업로드 prefix (후속) | `uploads/chat/{userId}/{messageId}.{ext}` — 비공개 유지 |
+
+## 트레이드오프 (왜 R2 X)
+
+| 차원 | AWS S3 | Cloudflare R2 |
+|---|---|---|
+| egress 비용 | $0.09/GB out | **무료** |
+| storage 비용 | $0.023/GB·월 | $0.015/GB·월 |
+| 도메인 통합 | CloudFront 추가 필요 | Cloudflare DNS 직결 |
+| AWS 생태계 통합 | IAM·CloudWatch 깊음 | 별도 |
+| 학습 곡선 | aws-cli (이미 익숙) | wrangler (새로) |
+
+**S3 선택 이유**:
+- AWS 친숙도 (EC2·SSM·OIDC CD 이미 보유 — [learning 37](../../learning/37-cd-pipeline-design.md))
+- 자산 크기 작음 (현재 mp3 6.7MB) → egress 비용 < $1/월
+- 채팅 이미지·NPC 음성·정적 에셋 통일로 운영 스택 1개
+
+**재검토 트리거**: 월 egress > $5 / 글로벌 사용자 비중 > 30% / 자산 합산 > 1GB
+
+## 운영 매뉴얼 (재현 가능한 설정)
+
+### 1. Block Public Access 일부 해제
+
+콘솔 → S3 → 버킷 → Permissions → "Block public access" → Edit:
+
+- 상단 "모든 퍼블릭 액세스 차단" → **해제**
+- 4개 개별 설정:
+  - ✅ 유지: "새 ACL ... 차단" (ACL 안 씀)
+  - ✅ 유지: "임의의 ACL ... 차단" (ACL 안 씀)
+  - ⬜ 해제: "새 퍼블릭 버킷 또는 액세스 지점 정책 ... 차단"
+  - ⬜ 해제: "임의의 퍼블릭 버킷 또는 액세스 지점 정책 ... 퍼블릭 및 교차 계정 액세스 차단"
+
+저장 시 "confirm" 입력.
+
+### 2. Bucket Policy (public read on `v1/*`)
+
+Permissions → "Bucket policy" → Edit → 붙여넣기 → Save:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "PublicReadV1Assets",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::gohyang-s3-buket-20260514/v1/*"
+    }
+  ]
+}
+```
+
+`v1/` prefix만 public read. `uploads/` 결로 결로 결로 결로 결로 결로 결로 결로 (사용자 업로드 결로 비공개 유지 — 후속 트랙에서 별도 sigv4 또는 presigned URL 결로 결로 결로 결로).
+
+### 3. CORS (브라우저 cross-origin fetch 허용)
+
+Permissions → "Cross-origin resource sharing (CORS)" → Edit → 붙여넣기 → Save:
+
+```json
+[
+  {
+    "AllowedHeaders": ["*"],
+    "AllowedMethods": ["GET", "HEAD"],
+    "AllowedOrigins": [
+      "https://ghworld.co",
+      "https://www.ghworld.co",
+      "http://localhost:3000"
+    ],
+    "ExposeHeaders": [],
+    "MaxAgeSeconds": 3000
+  }
+]
+```
+
+### 4. IAM Role (GitHub Actions OIDC — Step 3에서 박힘)
+
+Step 3 CD sync workflow 결로 필요. 기존 OIDC role(`learning 37` 참조)에 정책 추가:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::gohyang-s3-buket-20260514",
+        "arn:aws:s3:::gohyang-s3-buket-20260514/v1/*"
+      ]
+    }
+  ]
+}
+```
+
+> 본 Step 1에서는 정책 정의만 박아두고, 실제 권한 부착은 Step 3 결로.
+
+## versioned prefix 패턴
+
+자산 갱신 시 prefix를 `v1` → `v2`로 올려서 **브라우저·CDN 캐시 일괄 무효화**.
+
+```
+s3://gohyang-s3-buket-20260514/v1/audio/ambient/gentle-wind.mp3   ← 현재
+s3://gohyang-s3-buket-20260514/v2/audio/ambient/gentle-wind.mp3   ← 다음 결로 결로 결로 결로
+```
+
+전환 시 동시 갱신:
+- `NEXT_PUBLIC_ASSETS_BASE_URL` (frontend env)
+- GitHub Actions sync target prefix
+- 이 ADR 결로 결로 결로 결로
+
+> 첫 전환 절차는 Step 2~4 끝나고 정형화.
+
+## 빈틈·재검토 트리거
+
+- **CORS 헤더 직접 관리** — CloudFront 도입 후 단순화 가능
+- **캐시 TTL S3 기본값** — 매 요청 fetch. CloudFront 또는 Cloudflare proxy 결로 결로 결로 결로 결로 결로 (latency 부담 발견 시)
+- **다중 리전·글로벌 사용자 latency** — CloudFront 후속
+- **자산 합산 > 1GB** — R2 마이그 재검토 결로 결로 결로 결로 결로 결로 결로
+
+## 후속 결정
+
+- Step 2 — `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수 패턴 (learning 52 결로)
+- Step 3 — GitHub Actions sync workflow + OIDC 권한 추가
+- Step 4 — BGM mp3 + `BgmManager.ts` 통합 + D11 가드 (≤0.3)
+- 후속 트랙 — `s3-media-uploads` (채팅 이미지 결로 비공개 sigv4·presigned URL)
+
+## 참조
+
+- spec: [`docs/specs/features/s3-media.md`](../../specs/features/s3-media.md)
+- 트랙: [`docs/handover/track-s3-media.md`](../../handover/track-s3-media.md)
+- 환경음 무음 root cause: `frontend/.gitignore:44-50` + `frontend/public/assets/audio/ambient/README.md`
+- 기존 CD 인프라: [learning 37](../../learning/37-cd-pipeline-design.md), [learning 35](../../learning/35-aws-ec2-first-deployment.md)
+- TLS·도메인 인프라: [learning 65](../../learning/65-cookie-security-attributes-deep-dive.md), `infra-tls-hardening` 트랙

--- a/docs/architecture/decisions/009-s3-asset-hosting.md
+++ b/docs/architecture/decisions/009-s3-asset-hosting.md
@@ -10,7 +10,7 @@
 
 운영 환경(`ghworld.co`)에서 환경음 4종 + BGM 무음 상태. 원인:
 
-- `frontend/.gitignore:44-50` 결로 mp3 추적 X (spec D4' "외부 인프라 마이그 예정" 결로 미뤄둠)
+- `frontend/.gitignore:44-50`에서 mp3 추적 X (spec D4' "외부 인프라 마이그 예정" 결정으로 미뤄둠)
 - Docker 이미지 빌드 컨텍스트에 mp3 미포함 → 컨테이너 재시작/재배포 시마다 무음
 - 사용자가 BGM mp3를 EC2에 SCP로 직접 올렸으나, 새 이미지 배포 시 사라짐
 
@@ -87,7 +87,7 @@ Permissions → "Bucket policy" → Edit → 붙여넣기 → Save:
 }
 ```
 
-`v1/` prefix만 public read. `uploads/` 결로 결로 결로 결로 결로 결로 결로 결로 (사용자 업로드 결로 비공개 유지 — 후속 트랙에서 별도 sigv4 또는 presigned URL 결로 결로 결로 결로).
+`v1/` prefix만 public read. `uploads/` 같은 사용자 업로드 경로는 비공개 유지 — 후속 트랙에서 sigv4 또는 presigned URL로 접근 제공.
 
 ### 3. CORS (브라우저 cross-origin fetch 허용)
 
@@ -111,29 +111,39 @@ Permissions → "Cross-origin resource sharing (CORS)" → Edit → 붙여넣기
 
 ### 4. IAM Role (GitHub Actions OIDC — Step 3에서 박힘)
 
-Step 3 CD sync workflow 결로 필요. 기존 OIDC role(`learning 37` 참조)에 정책 추가:
+Step 3 CD sync workflow에서 필요. 기존 OIDC role(`learning 37` 참조)에 정책 추가:
 
 ```json
 {
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "ListV1Prefix",
+      "Effect": "Allow",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::gohyang-s3-buket-20260514",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": ["v1/*"]
+        }
+      }
+    },
+    {
+      "Sid": "WriteV1Objects",
       "Effect": "Allow",
       "Action": [
         "s3:PutObject",
-        "s3:DeleteObject",
-        "s3:ListBucket"
+        "s3:DeleteObject"
       ],
-      "Resource": [
-        "arn:aws:s3:::gohyang-s3-buket-20260514",
-        "arn:aws:s3:::gohyang-s3-buket-20260514/v1/*"
-      ]
+      "Resource": "arn:aws:s3:::gohyang-s3-buket-20260514/v1/*"
     }
   ]
 }
 ```
 
-> 본 Step 1에서는 정책 정의만 박아두고, 실제 권한 부착은 Step 3 결로.
+> 두 Statement로 분리한 이유: `s3:ListBucket`은 bucket-level action (object ARN에 못 붙음), `s3:PutObject`·`s3:DeleteObject`는 object-level action. ListBucket을 `s3:prefix` Condition으로 제한해서 CD가 `v1/` 밖을 못 본다.
+>
+> 본 Step 1에서는 정책 정의만 박아두고, 실제 권한 부착은 Step 3에서.
 
 ## versioned prefix 패턴
 
@@ -141,29 +151,29 @@ Step 3 CD sync workflow 결로 필요. 기존 OIDC role(`learning 37` 참조)에
 
 ```
 s3://gohyang-s3-buket-20260514/v1/audio/ambient/gentle-wind.mp3   ← 현재
-s3://gohyang-s3-buket-20260514/v2/audio/ambient/gentle-wind.mp3   ← 다음 결로 결로 결로 결로
+s3://gohyang-s3-buket-20260514/v2/audio/ambient/gentle-wind.mp3   ← 다음 세대 (전환 후)
 ```
 
 전환 시 동시 갱신:
 - `NEXT_PUBLIC_ASSETS_BASE_URL` (frontend env)
 - GitHub Actions sync target prefix
-- 이 ADR 결로 결로 결로 결로
+- 이 ADR의 인프라 사양 표 + 운영 매뉴얼 prefix
 
 > 첫 전환 절차는 Step 2~4 끝나고 정형화.
 
 ## 빈틈·재검토 트리거
 
 - **CORS 헤더 직접 관리** — CloudFront 도입 후 단순화 가능
-- **캐시 TTL S3 기본값** — 매 요청 fetch. CloudFront 또는 Cloudflare proxy 결로 결로 결로 결로 결로 결로 (latency 부담 발견 시)
+- **캐시 TTL S3 기본값** — 매 요청 fetch. CloudFront 또는 Cloudflare proxy로 캐시 레이어 보강 (latency 부담 발견 시)
 - **다중 리전·글로벌 사용자 latency** — CloudFront 후속
-- **자산 합산 > 1GB** — R2 마이그 재검토 결로 결로 결로 결로 결로 결로 결로
+- **자산 합산 > 1GB** — R2 마이그 재검토 (egress 비용 임계치 도달 시)
 
 ## 후속 결정
 
-- Step 2 — `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수 패턴 (learning 52 결로)
+- Step 2 — `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수 패턴 (learning 52에서 정리 예정)
 - Step 3 — GitHub Actions sync workflow + OIDC 권한 추가
-- Step 4 — BGM mp3 + `BgmManager.ts` 통합 + D11 가드 (≤0.3)
-- 후속 트랙 — `s3-media-uploads` (채팅 이미지 결로 비공개 sigv4·presigned URL)
+- ~~Step 4 — BGM mp3 + `BgmManager.ts` 통합~~ — **폐기 (2026-05-18)**: BGM = 환경음 4종으로 확정. 별도 BGM 매니저 만들지 않음
+- 후속 트랙 — `s3-media-uploads` (채팅 이미지용 비공개 sigv4·presigned URL)
 
 ## 참조
 

--- a/docs/handover/INDEX.md
+++ b/docs/handover/INDEX.md
@@ -13,8 +13,10 @@
 | 트랙 ID | 파일 | 작업 영역 | 상태 | 이슈 | 시작일 |
 |---------|------|-----------|------|------|--------|
 | `harden-village-ops` | [track-harden-village-ops.md](./track-harden-village-ops.md) | 백엔드 운영 P1 — UserRegisteredEventConsumer release + JWT_SECRET 폴백 제거 + 동시성 unit test | 🔧 Step 1 진행 (release + 테스트 박힘, PR #95) | #92 | 2026-05-17 |
+| `s3-media` | [track-s3-media.md](./track-s3-media.md) | 정적 에셋 외부 호스팅 인프라 — AWS S3 + CD 자동 sync + BGM 운영 정상화 + 도서관 자산 토대 | 🔧 Step 1 진행 (AWS S3 + IAM + CORS + ADR) | #89 | 2026-05-17 |
 
 > PR #94 (트랙 ⓒ ai-native-2026-05-upgrade) 머지 직후 트랙 ⓑ `harden-village-ops` 활성. Step 1 (UserRegisteredEventConsumer release + 회귀 테스트 + Codex P1 acquired flag) 진행 중.
+> 트랙 `s3-media` 병렬 활성 (2026-05-17) — 영역 분리 (백엔드 vs frontend/AWS S3/CD). 충돌 위험 파일은 각 트랙 파일 §4 참조.
 > Planned: skills-progressive-disclosure (Step 4·5) / anthropic-outcomes-trial (Step 6) / npc-evaluator-lmops 보강 (sweep v2 §B·§E).
 > ws-redis Step 3 도 후보. `track-ws-redis.md` §9 인수인계 참조.
 
@@ -46,7 +48,6 @@
 | `anthropic-outcomes-trial` | Anthropic Outcomes public beta 시범 — 우리 spec verification 과 자동 grader 결합 가능성 | 트랙 ⓒ Step 6 분리 산출. sweep v2 §D.2 출처. |
 | `npc-evaluator-lmops` 보강 | Langfuse self-host + OpenLIT + Grafana Anthropic prebuilt (sweep v2 §B·§E) | 사전 ADR learning 68 의 보강. sweep v2 결과 매트릭스 직접 반영. |
 | `token-auto-renewal` | Issue #38 — refresh token + rotation, HttpOnly cookie 발급, WS 토큰 갱신, 게스트 영속 식별자 | 수행계획서·결정 게이트 통과·구현계획서 [track-token-auto-renewal.md](./track-token-auto-renewal.md) 에 보존. **2026-05-02 재차 보류** — Redis 저장소 선택의 5패턴 비교 + 블로그 포스팅까지 깊이 있게 가져갈 주제로 판단, UI 디자인 트랙 우선 처리 후 재개 |
-| `s3-media` | S3 도입 (집 배경 이미지, 캐릭터 등) | 사전 결정 필요: 무엇을 올릴지 / 비용 정책 / 유해 필터 |
 
 > 시작 시점에 위 표에서 빼서 "활성 트랙" 표로 옮긴다.
 

--- a/docs/handover/track-s3-media.md
+++ b/docs/handover/track-s3-media.md
@@ -14,18 +14,20 @@
 
 > spec §6 Verification 과 1:1 매핑. 트랙 종료 시 같이 체크.
 
-- [ ] S3 버킷 생성 + public read 정책 + CORS 결로 `ghworld.co` origin 허용 확인 (AWS 콘솔 + curl 결로 검증)
-- [ ] frontend 빌드 시 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수 결로 S3 URL 주입 확인
-- [ ] dev `npm run dev` 결로 환경음 4종 + BGM 정상 재생
-- [ ] prod 배포 후 운영 환경(`ghworld.co`)에서 환경음 4종 + BGM 정상 재생 (현재 무음 해결 — 사용자 결로 청취 검증)
-- [ ] GitHub Actions workflow 결로 `frontend/assets/` 변경 → S3 sync 자동 실행 확인
-- [ ] BGM 음량 ≤ 0.3 (D11 가드) 코드 강제 확인 (`BgmManager.ts` 결로 상수 + 단위 테스트)
-- [ ] LICENSE.md 결로 BGM 곡 출처·라이선스 명시
+- [ ] S3 버킷 생성 + public read 정책 (`v1/*` 한정) + CORS의 `ghworld.co` origin 허용 확인 (AWS 콘솔 + curl로 검증)
+- [ ] frontend 빌드 시 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수로 S3 URL 주입 확인
+- [ ] dev `npm run dev`에서 환경음 4종 정상 재생
+- [ ] prod 배포 후 운영 환경(`ghworld.co`)에서 환경음 4종 정상 재생 (현재 무음 해결 — 사용자 청취 검증)
+- [ ] GitHub Actions workflow가 `frontend/assets/` 변경 시 S3 sync 자동 실행 확인
+- [ ] 환경음 D11 음량 가드 (≤ 0.3) 코드 강제 확인 (기존 `AmbientSoundManager` + `sound-config.ts`의 maxVolume 상수)
+- [ ] LICENSE.md에 환경음 4곡 출처·라이선스 명시
 - [ ] 학습노트 51 (R2 vs S3 ADR + versioned prefix) + 52 (frontend 자산 외부화 패턴) 작성 완료
 
 ## 1. 배경 / 왜
 
-운영 환경에서 환경음·BGM 모두 무음 — 원인은 `frontend/.gitignore`로 mp3 추적 X (spec D4' "외부 인프라 마이그 예정" 결로 미뤄둠) 결로 Docker 이미지에 자산 미포함. 사용자가 BGM mp3를 EC2에 SCP로 올렸으나 새 이미지 배포마다 사라짐.
+운영 환경에서 환경음·BGM 모두 무음 — 원인은 `frontend/.gitignore`로 mp3 추적 X (spec D4' "외부 인프라 마이그 예정" 결정으로 미뤄둠) → Docker 이미지에 자산 미포함. 사용자가 BGM mp3를 EC2에 SCP로 올렸으나 새 이미지 배포마다 사라짐.
+
+> **2026-05-18 갱신**: BGM = 환경음 4종으로 확정 (별도 BGM 곡 없음). spec D6 (BgmManager 분리) 폐기 — 별도 매니저 만들지 않음. Step 4 (BGM 신규) 폐기 → 4 step → 3 step.
 
 도서관 트랙에서 자산이 더 늘어날 예정 (3D 인테리어·NPC 음성·채팅 이미지) — 지금 git에 묶었다가 빼는 두 번 일을 피하기 위해 정석으로 외부화.
 
@@ -38,10 +40,10 @@
 
 | Step | 내용 | 의존 | 상태 | 이슈 | PR |
 |------|------|------|------|------|-----|
-| 1 | AWS S3 버킷 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + `docs/architecture/decisions/{NNN}-s3-asset-hosting.md` ADR | — | 🔧 진행 | #89 | (작업 시 채움) |
-| 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·`.env.local` 분리 + `.gitignore` 정리 | step 1 | 대기 | #89 | — |
+| 1 | AWS S3 버킷 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + `docs/architecture/decisions/009-s3-asset-hosting.md` ADR | — | 🔧 리뷰 대응 | #89 | #96 |
+| 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·`.env.local` 분리 + `.gitignore` 정리 + LICENSE.md (환경음 4곡) | step 1 | 대기 | #89 | — |
 | 3 | GitHub Actions workflow + OIDC IAM role 권한 추가 + `aws s3 sync` 자동화 | step 1 | 대기 | #89 | — |
-| 4 | BGM mp3 S3 업로드 + `BgmManager.ts` 신규 + VillageScene 통합 + D11 가드(≤0.3) + LICENSE.md | step 2, 3 | 대기 | #89 | — |
+| ~~4~~ | ~~BGM mp3 + BgmManager.ts 신규~~ — **폐기 (2026-05-18)**: BGM = 환경음 4종으로 확정 | — | 폐기 | — | — |
 
 ## 3. 현재 단계 상세
 
@@ -49,21 +51,21 @@
 
 **작업 항목**:
 
-1. AWS 콘솔 결로 S3 버킷 신설 (`ap-northeast-2`, 이름 결로 결정 — 후보: `maeum-gohyang-assets`)
-2. 버킷 정책 — public read (정적 자산 전체. 사용자 업로드 `uploads/`는 후속 트랙)
+1. AWS 콘솔에서 S3 버킷 신설 (`ap-northeast-2`, 이름: `gohyang-s3-buket-20260514` — 2026-05-17 확정)
+2. 버킷 정책 — `v1/*` prefix만 public read (사용자 업로드 `uploads/`는 후속 트랙에서 비공개 sigv4·presigned)
 3. CORS 설정 — `https://ghworld.co` + `https://www.ghworld.co` + `http://localhost:3000` (dev) origin 허용
-4. IAM role 결로 GitHub Actions OIDC 결로 `s3:PutObject`·`s3:DeleteObject` 권한 추가 (Step 3 결로 결로 결로 결로 결로 결로 — Step 1 결로 정책 박아둠)
-5. ADR 작성 — `docs/architecture/decisions/{NNN}-s3-asset-hosting.md`
+4. IAM role — GitHub Actions OIDC에 `s3:PutObject`·`s3:DeleteObject` (object-level) + `s3:ListBucket` (bucket-level, `s3:prefix=v1/*` Condition) 권한 추가 (실제 부착은 Step 3, Step 1에선 정책 정의만 박아둠)
+5. ADR 작성 — `docs/architecture/decisions/009-s3-asset-hosting.md`
    - 결정: S3 통일 (R2 X), raw URL 시작 (CloudFront 후속), versioned prefix
    - 트레이드오프: spec.decisions D1·D2·D5와 동기화
-6. spec §4 결로 결로 결로 결로 결로 결로 결로 결로 결로 결로 (decisions 변경 시)
+6. spec §4 갱신 (decisions 변경 시)
 
 **결정 사항** (spec §4 미리 박혔음 — Comprehension Gate 자동 통과):
 - D1 스토리지 = S3 (R2 X)
 - D2 도메인 = raw S3 URL (CloudFront 후속)
 - D5 폴더 = versioned prefix (`v1/`)
 
-**막힌 지점**: 없음. AWS 콘솔 수동 작업이 사용자 결로 필요.
+**막힌 지점**: 없음. AWS 콘솔 수동 작업은 사용자가 진행 완료 (2026-05-17).
 
 ## 4. 충돌 위험 파일
 
@@ -73,25 +75,25 @@
 |------|------|-----------|------|
 | `docs/handover/INDEX.md` | 1 | 모두 | 트랙 추가/제거 시 충돌. 본 트랙은 이미 활성 표 박힘 (2026-05-17) |
 | `docs/handover.md` | 1 | 모두 | **트랙 머지 PR 안에서만 갱신** — 진행 중에는 손대지 않음 |
-| `docs/learning/RESERVED.md` | 1 | 모두 | 본 트랙 결로 51·52 이미 예약 |
-| `frontend/.gitignore` | 1 | `harden-village-ops` 가능성 낮음 | 본 트랙 결로 mp3 정책 정리 |
-| `frontend/package.json`·`package-lock.json` | 1 | Dependabot | 본 트랙 결로 손대지 않음 (의존성 변경 없음) |
+| `docs/learning/RESERVED.md` | 1 | 모두 | 본 트랙용 51·52 이미 예약 |
+| `frontend/.gitignore` | 1 | `harden-village-ops` 가능성 낮음 | 본 트랙에서 mp3 정책 정리 |
+| `frontend/package.json`·`package-lock.json` | 1 | Dependabot | 본 트랙에선 손대지 않음 (의존성 변경 없음) |
 | `.github/workflows/` | 1 | 거의 없음 | Step 3에서 신규 workflow 추가 (`asset-sync.yml`). 기존 workflow 수정 X |
-| `frontend/src/three/audio/*` | 2 | 본 트랙 전용 | `BgmManager.ts` 신규, `sound-config.ts` 수정 |
-| `frontend/public/assets/audio/` | 2 | 본 트랙 전용 | Step 4 결로 mp3 추가 (git 추적 X 유지) |
+| `frontend/src/three/audio/*` | 2 | 본 트랙 전용 | Step 2에서 `sound-config.ts` 환경변수화 수정 (BgmManager 신규 폐기) |
+| `frontend/public/assets/audio/` | 2 | 본 트랙 전용 | 자산은 S3 호스팅 (git 추적 X 유지). LICENSE.md만 git 추적 |
 
 ## 5. 다음 세션 착수 전 확인 사항
 
 - main 동기화 (`git pull origin main`) — 다른 트랙 머지 시 변경 사항 점검
 - `harden-village-ops` 트랙 상태 — PR #95 머지됐는지 (`gh pr list`)
-- AWS 콘솔 접근 — Step 1 수동 작업 결로
-- 사용자 보유 BGM mp3 파일 경로 확인 (Step 4 결로 S3 업로드 결로 결로 결로)
+- AWS 콘솔 접근 — Step 1 수동 작업용 (2026-05-17 진행 완료)
+- 사용자 S3 업로드 상태 — `v1/audio/ambient/` 4종 (2026-05-17 완료)
 
 ## 6. 보류 메모
 
 - **CloudFront 도입** — raw S3 URL 시작, 후속 트랙. 트리거: latency 불만 / 캐시 hit ratio 부족 / 자산 합산 > 1GB
 - **`uploads/chat/` 활성화** — 채팅 이미지 트랙으로 분리 (사용자 업로드 정책·유해 필터 별도 결정)
 - **도서관 3D 모델 마이그** — 도서관 트랙으로 분리 (자산 폴더 구조 `v1/models/` 만 미리 박음)
-- **BGM 곡 수 확장** — scene 별 분기 결로 결로 결로 (현재 마을·도서관 동일 곡). 트리거: 사용자 피드백 결로 곡 단조 결로
-- **자산 압축 자동화** — mp3 비트레이트 결로 결로 결로 결로 (현재 사용자 사전 가공)
+- **BGM 곡 수 확장** — scene별 분기 가능성 (현재 마을·도서관 동일 환경음). 트리거: 사용자 피드백으로 단조롭다는 평
+- **자산 압축 자동화** — mp3 비트레이트 자동 조정 (현재 사용자 사전 가공)
 - **모니터링/알람** — S3 4xx·5xx 메트릭. 후속 인프라 트랙

--- a/docs/handover/track-s3-media.md
+++ b/docs/handover/track-s3-media.md
@@ -1,0 +1,97 @@
+# Track: s3-media
+
+> 작업 영역: 정적 에셋 외부 호스팅 인프라 (AWS S3 통일). BGM 운영 무음 문제 해결 + 환경음 운영 정상화 + 도서관/캐릭터/채팅 이미지 자산 토대.
+> 시작일: 2026-05-17
+> Issue: [#89](https://github.com/zkzkzhzj/ChatAppProject/issues/89)
+> 브랜치: `infra/s3-media-step1` (Step 1) — 후속 step은 step 별 브랜치 분기
+> Spec: [docs/specs/features/s3-media.md](../specs/features/s3-media.md)
+
+## 0. 한 줄 요약
+
+운영 환경에서 무음인 환경음·BGM을 살리고, 향후 도서관·NPC·채팅 자산까지 한 S3 버킷 + versioned prefix로 통일한다.
+
+## 0.5 Acceptance Criteria (이게 통과하면 트랙 종료)
+
+> spec §6 Verification 과 1:1 매핑. 트랙 종료 시 같이 체크.
+
+- [ ] S3 버킷 생성 + public read 정책 + CORS 결로 `ghworld.co` origin 허용 확인 (AWS 콘솔 + curl 결로 검증)
+- [ ] frontend 빌드 시 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수 결로 S3 URL 주입 확인
+- [ ] dev `npm run dev` 결로 환경음 4종 + BGM 정상 재생
+- [ ] prod 배포 후 운영 환경(`ghworld.co`)에서 환경음 4종 + BGM 정상 재생 (현재 무음 해결 — 사용자 결로 청취 검증)
+- [ ] GitHub Actions workflow 결로 `frontend/assets/` 변경 → S3 sync 자동 실행 확인
+- [ ] BGM 음량 ≤ 0.3 (D11 가드) 코드 강제 확인 (`BgmManager.ts` 결로 상수 + 단위 테스트)
+- [ ] LICENSE.md 결로 BGM 곡 출처·라이선스 명시
+- [ ] 학습노트 51 (R2 vs S3 ADR + versioned prefix) + 52 (frontend 자산 외부화 패턴) 작성 완료
+
+## 1. 배경 / 왜
+
+운영 환경에서 환경음·BGM 모두 무음 — 원인은 `frontend/.gitignore`로 mp3 추적 X (spec D4' "외부 인프라 마이그 예정" 결로 미뤄둠) 결로 Docker 이미지에 자산 미포함. 사용자가 BGM mp3를 EC2에 SCP로 올렸으나 새 이미지 배포마다 사라짐.
+
+도서관 트랙에서 자산이 더 늘어날 예정 (3D 인테리어·NPC 음성·채팅 이미지) — 지금 git에 묶었다가 빼는 두 번 일을 피하기 위해 정석으로 외부화.
+
+- 관련 spec: [s3-media.md](../specs/features/s3-media.md)
+- 관련 learning (예약): 51 (R2 vs S3 ADR), 52 (frontend 자산 외부화 패턴)
+- 기존 OIDC CD 인프라: [learning 37](../learning/37-cd-pipeline-design.md)
+- 환경음 무음 root cause: `frontend/.gitignore:44-50` + `frontend/public/assets/audio/ambient/README.md`
+
+## 2. 전체 로드맵 (1 step = 1 PR — git.md §4)
+
+| Step | 내용 | 의존 | 상태 | 이슈 | PR |
+|------|------|------|------|------|-----|
+| 1 | AWS S3 버킷 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + `docs/architecture/decisions/{NNN}-s3-asset-hosting.md` ADR | — | 🔧 진행 | #89 | (작업 시 채움) |
+| 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·`.env.local` 분리 + `.gitignore` 정리 | step 1 | 대기 | #89 | — |
+| 3 | GitHub Actions workflow + OIDC IAM role 권한 추가 + `aws s3 sync` 자동화 | step 1 | 대기 | #89 | — |
+| 4 | BGM mp3 S3 업로드 + `BgmManager.ts` 신규 + VillageScene 통합 + D11 가드(≤0.3) + LICENSE.md | step 2, 3 | 대기 | #89 | — |
+
+## 3. 현재 단계 상세
+
+### Step 1 — AWS S3 + IAM + CORS + ADR
+
+**작업 항목**:
+
+1. AWS 콘솔 결로 S3 버킷 신설 (`ap-northeast-2`, 이름 결로 결정 — 후보: `maeum-gohyang-assets`)
+2. 버킷 정책 — public read (정적 자산 전체. 사용자 업로드 `uploads/`는 후속 트랙)
+3. CORS 설정 — `https://ghworld.co` + `https://www.ghworld.co` + `http://localhost:3000` (dev) origin 허용
+4. IAM role 결로 GitHub Actions OIDC 결로 `s3:PutObject`·`s3:DeleteObject` 권한 추가 (Step 3 결로 결로 결로 결로 결로 결로 — Step 1 결로 정책 박아둠)
+5. ADR 작성 — `docs/architecture/decisions/{NNN}-s3-asset-hosting.md`
+   - 결정: S3 통일 (R2 X), raw URL 시작 (CloudFront 후속), versioned prefix
+   - 트레이드오프: spec.decisions D1·D2·D5와 동기화
+6. spec §4 결로 결로 결로 결로 결로 결로 결로 결로 결로 결로 (decisions 변경 시)
+
+**결정 사항** (spec §4 미리 박혔음 — Comprehension Gate 자동 통과):
+- D1 스토리지 = S3 (R2 X)
+- D2 도메인 = raw S3 URL (CloudFront 후속)
+- D5 폴더 = versioned prefix (`v1/`)
+
+**막힌 지점**: 없음. AWS 콘솔 수동 작업이 사용자 결로 필요.
+
+## 4. 충돌 위험 파일
+
+> 다른 트랙 (`harden-village-ops` 백엔드 운영) 과 영역 분리되어 있어 충돌 위험 낮음. parallel-work.md §3 Tier 분류 참조.
+
+| 파일 | Tier | 동시 트랙 | 비고 |
+|------|------|-----------|------|
+| `docs/handover/INDEX.md` | 1 | 모두 | 트랙 추가/제거 시 충돌. 본 트랙은 이미 활성 표 박힘 (2026-05-17) |
+| `docs/handover.md` | 1 | 모두 | **트랙 머지 PR 안에서만 갱신** — 진행 중에는 손대지 않음 |
+| `docs/learning/RESERVED.md` | 1 | 모두 | 본 트랙 결로 51·52 이미 예약 |
+| `frontend/.gitignore` | 1 | `harden-village-ops` 가능성 낮음 | 본 트랙 결로 mp3 정책 정리 |
+| `frontend/package.json`·`package-lock.json` | 1 | Dependabot | 본 트랙 결로 손대지 않음 (의존성 변경 없음) |
+| `.github/workflows/` | 1 | 거의 없음 | Step 3에서 신규 workflow 추가 (`asset-sync.yml`). 기존 workflow 수정 X |
+| `frontend/src/three/audio/*` | 2 | 본 트랙 전용 | `BgmManager.ts` 신규, `sound-config.ts` 수정 |
+| `frontend/public/assets/audio/` | 2 | 본 트랙 전용 | Step 4 결로 mp3 추가 (git 추적 X 유지) |
+
+## 5. 다음 세션 착수 전 확인 사항
+
+- main 동기화 (`git pull origin main`) — 다른 트랙 머지 시 변경 사항 점검
+- `harden-village-ops` 트랙 상태 — PR #95 머지됐는지 (`gh pr list`)
+- AWS 콘솔 접근 — Step 1 수동 작업 결로
+- 사용자 보유 BGM mp3 파일 경로 확인 (Step 4 결로 S3 업로드 결로 결로 결로)
+
+## 6. 보류 메모
+
+- **CloudFront 도입** — raw S3 URL 시작, 후속 트랙. 트리거: latency 불만 / 캐시 hit ratio 부족 / 자산 합산 > 1GB
+- **`uploads/chat/` 활성화** — 채팅 이미지 트랙으로 분리 (사용자 업로드 정책·유해 필터 별도 결정)
+- **도서관 3D 모델 마이그** — 도서관 트랙으로 분리 (자산 폴더 구조 `v1/models/` 만 미리 박음)
+- **BGM 곡 수 확장** — scene 별 분기 결로 결로 결로 (현재 마을·도서관 동일 곡). 트리거: 사용자 피드백 결로 곡 단조 결로
+- **자산 압축 자동화** — mp3 비트레이트 결로 결로 결로 결로 (현재 사용자 사전 가공)
+- **모니터링/알람** — S3 4xx·5xx 메트릭. 후속 인프라 트랙

--- a/docs/specs/features/s3-media.md
+++ b/docs/specs/features/s3-media.md
@@ -1,0 +1,165 @@
+---
+feature: s3-media
+track: s3-media
+issue: "#89"
+status: draft
+created: 2026-05-17
+last-updated: 2026-05-17
+---
+
+# 정적 에셋 외부 호스팅 인프라 (S3 + CD 자동 sync + BGM 운영 정상화)
+
+> 이 spec 은 트랙 `s3-media` (Issue #89) 의 **요구사항 진실** 이다.
+> 진행 상태는 `docs/handover/track-s3-media.md`, 결정의 사고 과정은 `docs/learning/51-*.md`·`docs/learning/52-*.md`.
+> 4층 분리 모델: [conventions/spec-driven.md](../../conventions/spec-driven.md) §1.
+
+---
+
+## 1. Outcomes
+
+> 이 spec 이 만족되면 무엇이 가능해지나? (유저 / 시스템 관점)
+
+- **유저**: 운영 환경(`ghworld.co`)에서 환경음 4종(gentle-wind·crackling-fire·pond-water·forest-birds) + BGM 1곡이 정상 재생된다 (현재 무음 상태 해결)
+- **유저**: BGM이 D11 안식처 가드레일(음량 ≤ 0.3) 내에서 잔잔하게 배경음 역할
+- **시스템**: mp3 자산이 git 추적되지 않아도 외부 S3 fetch 결로 운영 정상 작동
+- **시스템**: `frontend/assets/` 자산 변경 시 GitHub Actions 가 자동으로 S3 sync 실행 (수동 SCP 없음)
+- **시스템**: dev/prod 환경 모두 동일 S3 endpoint fetch (환경 분기 없음 — "내 컴에선 되는데" 방지)
+- **확장성**: 향후 도서관 3D 모델·NPC 음성·채팅 이미지 자산 모두 같은 S3 버킷 + versioned prefix(`v1/`)로 통일
+
+## 2. Scope
+
+### 2.1 In (이번 트랙에서 만든다)
+
+- AWS S3 버킷 신설 (`ap-northeast-2`, public read)
+- IAM 정책 + 버킷 정책 + CORS 설정 (`ghworld.co` origin 허용)
+- `frontend/public/assets/` 의 mp3 4종 → S3 마이그 (`s3://bucket/v1/audio/ambient/`)
+- 코드: `sound-config.ts` src 결로 환경변수 `NEXT_PUBLIC_ASSETS_BASE_URL` 결로 외부 URL 주입
+- GitHub Actions 자산 sync workflow (`frontend/assets/` 변경 감지 → `aws s3 sync`)
+- BGM `BgmManager.ts` 신규 (Howler.js, `AmbientSoundManager` 와 분리된 채널)
+- BGM 곡 1개 S3 업로드 + VillageScene 통합 + D11 가드(≤0.3) 코드 강제
+- LICENSE.md 갱신 (BGM 곡 출처·라이선스)
+- 루트 `package-lock.json` 동반 commit (husky/markdownlint 재현성)
+- `.gitignore` 정리 — 외부화 후 추적 정책 명시 (mp3 추적 X 유지 결로 결정 의도 박음)
+
+### 2.2 Out (이번 트랙에서 명시적으로 안 만든다)
+
+> Out 이 spec 가치의 절반. "안 만드는 것" 을 적어야 다음 세션이 스코프 침범 안 함.
+
+- **CloudFront 도입** — raw S3 URL 시작, 후속 트랙
+- **`uploads/chat/` 사용자 업로드 경로 활성화** — 채팅 이미지 트랙에서
+- **도서관 3D 모델 마이그** — 도서관 트랙에서 (자산 폴더 구조만 미리 박음)
+- **캐시 무효화 자동화** — 수동 prefix 갱신(`v1` → `v2`)으로 시작
+- **BGM 곡 수 확장** — 현재는 마을·도서관 동일 곡, 도서관에서 페이드만 (Scene 별 곡 분기는 후속)
+- **자산 압축 자동화** (mp3 결 결로 결로 결로 결로) — 사용자 사전 가공 결로 진행
+- **monitoring/알람** (S3 4xx·5xx 결로 결로 결로) — 후속 인프라 트랙
+
+## 3. Constraints (비기능 제약)
+
+| 차원 | 제약 |
+|------|------|
+| 성능 | mp3 초기 로드 latency < 1s (서울 리전 직접, mp3 < 5MB) |
+| 비용 | 월 < $1 예상 (자산 합산 < 50MB, egress < 5GB/월). S3 free tier 결로 0 가능 |
+| 시간 | 트랙 전체 4 step, 1~2 세션 예상 |
+| 인프라 | AWS EC2 + Cloudflare(SSL·DNS) 기존 구조 유지, 새 AWS 친화 결로 통일 |
+| 정책/규제 | D11 안식처 가드레일 6축 — 음량 ≤ 0.3, 잔잔한 결, EDM·시끄러운 BGM 위반 신호. 라이선스 LICENSE.md 명시 의무 |
+| 브라우저 | autoplay 정책 — 사용자 first interaction 필요 (`AmbientSoundManager` 기존 결로 유지, BGM도 동일 unlock 흐름) |
+
+## 4. Decisions
+
+> 각 결정마다 **왜 · 대안 · 빈틈 · 재검토 트리거 4축**.
+> Comprehension Gate (`docs/conventions/comprehension-gate.md`, P3 산출물) 의 13 카테고리·Tier 시스템과 1:1 매핑.
+> **미리 채우면 게이트가 자동 통과**. 빈 채로 진행하면 step 시점에 게이트가 묻는다.
+
+### D1. [새 기술·의존성] 스토리지 = AWS S3 (Cloudflare R2 X)
+
+- **왜**: AWS 친숙도(EC2·SSM·OIDC CD 이미 보유), 자산 크기 작음(현재 mp3 6.7MB) → egress 비용 < $1/월 결로 무시 가능. 채팅 이미지·NPC 음성·정적 에셋 통일로 운영 스택 1개
+- **대안**:
+  - Cloudflare R2 — egress 무료, Cloudflare DNS 직결. 자산 글로벌 fetch 임계치 미달이라 매력 작음. 신규 wrangler CLI 학습 비용
+  - .gitignore 예외 + git commit — MVP 결로 가장 단순. 다만 도서관 트랙 자산 늘어나면 두 번 일 (S3 마이그 강요)
+- **빈틈**: 다중 리전 / 글로벌 사용자 결로 fetch latency 부담. CloudFront 결로 후속 보강. 또한 사용자 업로드 비용(egress) 늘어나면 R2 재검토 필요
+- **재검토 트리거**: 월 egress > $5 / 글로벌 사용자 비중 > 30% / 자산 합산 > 1GB
+
+### D2. [API 설계] 도메인 = raw S3 URL (CloudFront 후속)
+
+- **왜**: 단순 시작. 자산 작아서 latency 부담 적음. `https://{bucket}.s3.ap-northeast-2.amazonaws.com/v1/audio/ambient/gentle-wind.mp3` 결로 직접
+- **대안**:
+  - CloudFront + `assets.ghworld.co` — SSL·캐싱·custom 도메인 정석. 다만 Route 53 또는 Cloudflare proxy 추가 작업, 트랙 범위 확장
+  - Cloudflare proxy (S3 origin) — 도메인 통합 OK. 다만 origin 설정 + cache rule 별도 작업
+- **빈틈**: CORS 헤더 직접 관리 필요. 캐시 TTL S3 기본값(없음 — 매 요청 fetch)
+- **재검토 트리거**: latency 불만 / S3 비용 (cache miss) / 도서관 트랙 자산 늘어남
+
+### D3. [환경 분기] 환경 = dev/prod 모두 외부 fetch
+
+- **왜**: 일관성. 환경 분기 디버깅 없음. dev에서도 진짜 운영 결로 검증. "내 컴에선 되는데" 방지
+- **대안**:
+  - dev = 로컬 mp3, prod = S3 — 오프라인 dev 가능. 다만 환경 분기 로직 필요 (`process.env.NODE_ENV` 분기)
+- **빈틈**: 오프라인 dev 안 됨. dev 시작 시 S3 접근 필요 (간헐적 네트워크 결로 dev UX 저하 가능)
+- **재검토 트리거**: 오프라인 dev 빈도 높음 / S3 latency dev 결로 지장 / 비행기 결로 작업 빈번
+
+### D4. [CD 파이프라인] CD 자동화 = GitHub Actions 묶음
+
+- **왜**: 자산 변경마다 수동 sync 부담. CD 자연 통합. OIDC 이미 결로 결로 결로 결로 (`docs/learning/37-cd-pipeline-design.md` 결로)
+- **대안**:
+  - 수동 `aws s3 sync` — 단순. 다만 잊어버리기 쉬움. 자산 변경 ↔ 배포 비동기 결로 운영 갈등
+- **빈틈**: GitHub Actions S3 credential 권한 (IAM role 결로 OIDC 결로 결로 결로 결로 결로). 기존 CD에 이미 OIDC 결로, 권한 정책만 추가
+- **재검토 트리거**: workflow 실패 빈번 / 자산 sync 누락 / IAM role 권한 결로 결로
+
+### D5. [API 설계] 폴더 = versioned prefix (`v1/`)
+
+- **왜**: 캐시 무효화 통합. 자산 갱신 결로 prefix 올려서 일괄 무효화 가능 (브라우저·CDN 캐시 1년 TTL 결로 결 박을 수 있음). 채팅 업로드(`uploads/`)는 별도 prefix(immutable URL 결로 캐시 무효화 무관)
+- **대안**:
+  - 평탄 구조 (`/audio/ambient/...`) — 단순. 다만 캐시 무효화 어려움 (개별 객체 invalidation 필요)
+- **빈틈**: v1 → v2 전환 시 코드(env var)·CD(sync target prefix)·도큐 동시 갱신 필요. 자동화 안 되면 누락 위험
+- **재검토 트리거**: 첫 prefix 전환 시 절차 정형화 / 자산 종류 늘어남 (운영 복잡도 측정)
+
+### D6. [헥사고날 경계] BGM = `BgmManager.ts` 신규 (AmbientSoundManager 결로 통합 X)
+
+- **왜**: 환경음(자연음, 위치 기반)과 BGM(곡, scene 기반)은 책임이 다름. 위치 모델(`SoundPositionModel`)은 환경음 결로만, BGM은 scene 별 single track. 통합 시 `calculateVolume`이 두 도메인 알아야 함 (단일 책임 위반)
+- **대안**:
+  - `AmbientSoundManager`에 BGM zone 추가 — 매니저 1개. 다만 책임 섞임, 곡 vs 자연음 동작 차이(crossfade·loop·license) 결로 결로 결로 결로 결로
+- **빈틈**: Howler.js 인스턴스 2개 결로 메모리·audio pool 결로 결로 결로 결로 결로 결로. `Howler.html5PoolSize = 30` 기존 설정 결로 결로 결로 (`AmbientSoundManager.ts:39` 참조)
+- **재검토 트리거**: BGM 곡 수 늘어남 (5곡 이상) / scene 별 BGM 분기 결로 결로 결로 (현재 마을·도서관 동일 곡)
+
+## 5. Tasks (= Steps)
+
+> **1 step = 1 PR (엄격)** — `docs/conventions/git.md` §4, `docs/conventions/spec-driven.md` §2.2.
+
+| Step | 내용 | 의존 | 예상 변경 영역 | 이슈 | PR |
+|------|------|------|---------------|------|-----|
+| 1 | AWS S3 버킷 생성 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + ADR 박음 | — | `docs/architecture/decisions/{NNN}-s3-asset-hosting.md` (신규), AWS 콘솔 (수동) | #89 | (작업 시 채움) |
+| 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·`.env.local` 분리 + `.gitignore` 정리 + 루트 `package-lock.json` commit | step 1 | `frontend/src/three/audio/sound-config.ts`, `frontend/.env*`, `frontend/.gitignore`, 루트 `package-lock.json` | #89 | ... |
+| 3 | GitHub Actions workflow 신규 (`frontend/assets/` 변경 감지 → `aws s3 sync`) + OIDC IAM role 권한 추가 | step 1 | `.github/workflows/asset-sync.yml` (신규), AWS IAM (수동) | #89 | ... |
+| 4 | BGM mp3 S3 업로드 + `BgmManager.ts` 신규 + VillageScene 통합 + D11 가드(≤0.3) + LICENSE.md 갱신 | step 2, 3 | `frontend/src/three/audio/BgmManager.ts` (신규), `frontend/src/three/audio/sound-config.ts`, `frontend/src/three/scenes/VillageScene.ts`, `frontend/public/assets/LICENSE.md` | #89 | ... |
+
+## 6. Verification (수용 기준)
+
+> 이게 통과하면 spec 종료. track 파일의 `§0.5 Acceptance Criteria` 와 1:1 매핑.
+
+- [ ] S3 버킷 생성 + public read 정책 + CORS 결로 `ghworld.co` origin 허용 확인 (AWS 콘솔 + curl 결로 검증)
+- [ ] frontend 빌드 시 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수 결로 S3 URL 주입 확인 (`npm run build` + 결과 결로 fetch URL 확인)
+- [ ] dev `npm run dev` 결로 환경음 4종 + BGM 정상 재생 (사용자 결로 청취 검증)
+- [ ] prod 배포 후 운영 환경(`ghworld.co`)에서 환경음 4종 + BGM 정상 재생 (현재 무음 해결 — 사용자 결로 청취 검증)
+- [ ] GitHub Actions workflow 결로 `frontend/assets/` 변경 → S3 sync 자동 실행 확인 (workflow run 로그 결로)
+- [ ] BGM 음량 ≤ 0.3 (D11 가드) 코드 강제 확인 (`BgmManager.ts` 결로 상수 + 단위 테스트 결로)
+- [ ] LICENSE.md 결로 BGM 곡 출처·라이선스 명시
+- [ ] 루트 `package-lock.json` commit 확인 (husky 재현성)
+- [ ] 학습노트 51 (R2 vs S3 ADR + versioned prefix) + 52 (frontend 자산 외부화 패턴) 작성 완료
+
+## 7. References
+
+- 트랙 파일: [track-s3-media.md](../../handover/track-s3-media.md) (`/track-start` 결로 신규 작성)
+- 관련 wiki: [frontend/asset-guide.md](../../wiki/frontend/asset-guide.md) (에셋 소스·라이선스·호스팅 정책), [infra/hooks-automation.md](../../wiki/infra/hooks-automation.md) (CD 자동화 결로)
+- 관련 learning: [37-cd-pipeline-design.md](../../learning/37-cd-pipeline-design.md) (기존 OIDC CD 파이프라인 기반), [78-next-three-howler-dev-memory-diagnosis.md](../../learning/78-next-three-howler-dev-memory-diagnosis.md) (Howler.js 결로 dev 메모리 결로 — BGM 추가 시 memory budget 주의)
+- 관련 ADR: `docs/architecture/decisions/{NNN}-s3-asset-hosting.md` (Step 1 결로 신규 박을 예정)
+- 외부 자료:
+  - AWS S3 CORS 설정: https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html
+  - GitHub Actions OIDC + AWS IAM: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
+  - Howler.js: https://howlerjs.com/
+
+---
+
+## 변경 이력
+
+| 날짜 | 변경 |
+|------|------|
+| 2026-05-17 | 초안 작성 (사용자 결정 4단계 사이클 — R2 vs S3 트레이드오프 결로 S3 통일 + raw URL + dev/prod 외부 + CD 자동 + versioned prefix). decisions 6축 미리 박음 결로 Comprehension Gate 자동 통과 의도 |

--- a/docs/specs/features/s3-media.md
+++ b/docs/specs/features/s3-media.md
@@ -21,7 +21,7 @@ last-updated: 2026-05-17
 
 - **유저**: 운영 환경(`ghworld.co`)에서 환경음 4종(gentle-wind·crackling-fire·pond-water·forest-birds) + BGM 1곡이 정상 재생된다 (현재 무음 상태 해결)
 - **유저**: BGM이 D11 안식처 가드레일(음량 ≤ 0.3) 내에서 잔잔하게 배경음 역할
-- **시스템**: mp3 자산이 git 추적되지 않아도 외부 S3 fetch 결로 운영 정상 작동
+- **시스템**: mp3 자산이 git 추적되지 않아도 외부 S3 fetch로 운영 정상 작동
 - **시스템**: `frontend/assets/` 자산 변경 시 GitHub Actions 가 자동으로 S3 sync 실행 (수동 SCP 없음)
 - **시스템**: dev/prod 환경 모두 동일 S3 endpoint fetch (환경 분기 없음 — "내 컴에선 되는데" 방지)
 - **확장성**: 향후 도서관 3D 모델·NPC 음성·채팅 이미지 자산 모두 같은 S3 버킷 + versioned prefix(`v1/`)로 통일
@@ -33,13 +33,13 @@ last-updated: 2026-05-17
 - AWS S3 버킷 신설 (`ap-northeast-2`, public read)
 - IAM 정책 + 버킷 정책 + CORS 설정 (`ghworld.co` origin 허용)
 - `frontend/public/assets/` 의 mp3 4종 → S3 마이그 (`s3://bucket/v1/audio/ambient/`)
-- 코드: `sound-config.ts` src 결로 환경변수 `NEXT_PUBLIC_ASSETS_BASE_URL` 결로 외부 URL 주입
+- 코드: `sound-config.ts`의 src를 환경변수 `NEXT_PUBLIC_ASSETS_BASE_URL`로 prefix해서 외부 URL 주입
 - GitHub Actions 자산 sync workflow (`frontend/assets/` 변경 감지 → `aws s3 sync`)
 - BGM `BgmManager.ts` 신규 (Howler.js, `AmbientSoundManager` 와 분리된 채널)
 - BGM 곡 1개 S3 업로드 + VillageScene 통합 + D11 가드(≤0.3) 코드 강제
 - LICENSE.md 갱신 (BGM 곡 출처·라이선스)
 - 루트 `package-lock.json` 동반 commit (husky/markdownlint 재현성)
-- `.gitignore` 정리 — 외부화 후 추적 정책 명시 (mp3 추적 X 유지 결로 결정 의도 박음)
+- `.gitignore` 정리 — 외부화 후 추적 정책 명시 (mp3 추적 X 유지 결정 의도 박음)
 
 ### 2.2 Out (이번 트랙에서 명시적으로 안 만든다)
 
@@ -50,19 +50,19 @@ last-updated: 2026-05-17
 - **도서관 3D 모델 마이그** — 도서관 트랙에서 (자산 폴더 구조만 미리 박음)
 - **캐시 무효화 자동화** — 수동 prefix 갱신(`v1` → `v2`)으로 시작
 - **BGM 곡 수 확장** — 현재는 마을·도서관 동일 곡, 도서관에서 페이드만 (Scene 별 곡 분기는 후속)
-- **자산 압축 자동화** (mp3 결 결로 결로 결로 결로) — 사용자 사전 가공 결로 진행
-- **monitoring/알람** (S3 4xx·5xx 결로 결로 결로) — 후속 인프라 트랙
+- **자산 압축 자동화** (mp3 비트레이트 자동 조정) — 사용자 사전 가공으로 진행
+- **monitoring/알람** (S3 4xx·5xx 메트릭) — 후속 인프라 트랙
 
 ## 3. Constraints (비기능 제약)
 
 | 차원 | 제약 |
 |------|------|
 | 성능 | mp3 초기 로드 latency < 1s (서울 리전 직접, mp3 < 5MB) |
-| 비용 | 월 < $1 예상 (자산 합산 < 50MB, egress < 5GB/월). S3 free tier 결로 0 가능 |
+| 비용 | 월 < $1 예상 (자산 합산 < 50MB, egress < 5GB/월). S3 free tier 내에선 0 가능 |
 | 시간 | 트랙 전체 4 step, 1~2 세션 예상 |
-| 인프라 | AWS EC2 + Cloudflare(SSL·DNS) 기존 구조 유지, 새 AWS 친화 결로 통일 |
+| 인프라 | AWS EC2 + Cloudflare(SSL·DNS) 기존 구조 유지, 신규 자산 호스팅은 AWS 친화 스택으로 통일 |
 | 정책/규제 | D11 안식처 가드레일 6축 — 음량 ≤ 0.3, 잔잔한 결, EDM·시끄러운 BGM 위반 신호. 라이선스 LICENSE.md 명시 의무 |
-| 브라우저 | autoplay 정책 — 사용자 first interaction 필요 (`AmbientSoundManager` 기존 결로 유지, BGM도 동일 unlock 흐름) |
+| 브라우저 | autoplay 정책 — 사용자 first interaction 필요 (`AmbientSoundManager` 기존 unlock 흐름 유지, BGM도 동일 흐름) |
 
 ## 4. Decisions
 
@@ -72,16 +72,16 @@ last-updated: 2026-05-17
 
 ### D1. [새 기술·의존성] 스토리지 = AWS S3 (Cloudflare R2 X)
 
-- **왜**: AWS 친숙도(EC2·SSM·OIDC CD 이미 보유), 자산 크기 작음(현재 mp3 6.7MB) → egress 비용 < $1/월 결로 무시 가능. 채팅 이미지·NPC 음성·정적 에셋 통일로 운영 스택 1개
+- **왜**: AWS 친숙도(EC2·SSM·OIDC CD 이미 보유), 자산 크기 작음(현재 mp3 6.7MB) → egress 비용 < $1/월로 무시 가능. 채팅 이미지·NPC 음성·정적 에셋 통일로 운영 스택 1개
 - **대안**:
   - Cloudflare R2 — egress 무료, Cloudflare DNS 직결. 자산 글로벌 fetch 임계치 미달이라 매력 작음. 신규 wrangler CLI 학습 비용
-  - .gitignore 예외 + git commit — MVP 결로 가장 단순. 다만 도서관 트랙 자산 늘어나면 두 번 일 (S3 마이그 강요)
-- **빈틈**: 다중 리전 / 글로벌 사용자 결로 fetch latency 부담. CloudFront 결로 후속 보강. 또한 사용자 업로드 비용(egress) 늘어나면 R2 재검토 필요
+  - .gitignore 예외 + git commit — MVP로는 가장 단순. 다만 도서관 트랙 자산 늘어나면 두 번 일 (S3 마이그 강요)
+- **빈틈**: 다중 리전 / 글로벌 사용자에게 fetch latency 부담. CloudFront로 후속 보강. 또한 사용자 업로드 비용(egress) 늘어나면 R2 재검토 필요
 - **재검토 트리거**: 월 egress > $5 / 글로벌 사용자 비중 > 30% / 자산 합산 > 1GB
 
 ### D2. [API 설계] 도메인 = raw S3 URL (CloudFront 후속)
 
-- **왜**: 단순 시작. 자산 작아서 latency 부담 적음. `https://{bucket}.s3.ap-northeast-2.amazonaws.com/v1/audio/ambient/gentle-wind.mp3` 결로 직접
+- **왜**: 단순 시작. 자산 작아서 latency 부담 적음. `https://{bucket}.s3.ap-northeast-2.amazonaws.com/v1/audio/ambient/gentle-wind.mp3` 형태로 직접
 - **대안**:
   - CloudFront + `assets.ghworld.co` — SSL·캐싱·custom 도메인 정석. 다만 Route 53 또는 Cloudflare proxy 추가 작업, 트랙 범위 확장
   - Cloudflare proxy (S3 origin) — 도메인 통합 OK. 다만 origin 설정 + cache rule 별도 작업
@@ -90,35 +90,37 @@ last-updated: 2026-05-17
 
 ### D3. [환경 분기] 환경 = dev/prod 모두 외부 fetch
 
-- **왜**: 일관성. 환경 분기 디버깅 없음. dev에서도 진짜 운영 결로 검증. "내 컴에선 되는데" 방지
+- **왜**: 일관성. 환경 분기 디버깅 없음. dev에서도 진짜 운영 endpoint로 검증. "내 컴에선 되는데" 방지
 - **대안**:
   - dev = 로컬 mp3, prod = S3 — 오프라인 dev 가능. 다만 환경 분기 로직 필요 (`process.env.NODE_ENV` 분기)
-- **빈틈**: 오프라인 dev 안 됨. dev 시작 시 S3 접근 필요 (간헐적 네트워크 결로 dev UX 저하 가능)
-- **재검토 트리거**: 오프라인 dev 빈도 높음 / S3 latency dev 결로 지장 / 비행기 결로 작업 빈번
+- **빈틈**: 오프라인 dev 안 됨. dev 시작 시 S3 접근 필요 (간헐적 네트워크 환경에서 dev UX 저하 가능)
+- **재검토 트리거**: 오프라인 dev 빈도 높음 / S3 latency가 dev에 지장 / 비행기 안에서 작업 빈번
 
 ### D4. [CD 파이프라인] CD 자동화 = GitHub Actions 묶음
 
-- **왜**: 자산 변경마다 수동 sync 부담. CD 자연 통합. OIDC 이미 결로 결로 결로 결로 (`docs/learning/37-cd-pipeline-design.md` 결로)
+- **왜**: 자산 변경마다 수동 sync 부담. CD 자연 통합. OIDC IAM role 기반 권한이 이미 박혀있음 (`docs/learning/37-cd-pipeline-design.md` 참조)
 - **대안**:
-  - 수동 `aws s3 sync` — 단순. 다만 잊어버리기 쉬움. 자산 변경 ↔ 배포 비동기 결로 운영 갈등
-- **빈틈**: GitHub Actions S3 credential 권한 (IAM role 결로 OIDC 결로 결로 결로 결로 결로). 기존 CD에 이미 OIDC 결로, 권한 정책만 추가
-- **재검토 트리거**: workflow 실패 빈번 / 자산 sync 누락 / IAM role 권한 결로 결로
+  - 수동 `aws s3 sync` — 단순. 다만 잊어버리기 쉬움. 자산 변경 ↔ 배포 비동기로 운영 갈등
+- **빈틈**: GitHub Actions S3 credential 권한 (IAM role + OIDC 신뢰 정책 갱신 필요). 기존 CD에 이미 OIDC가 박혀있어 권한 정책만 추가
+- **재검토 트리거**: workflow 실패 빈번 / 자산 sync 누락 / IAM role 권한 회수 필요 시
 
 ### D5. [API 설계] 폴더 = versioned prefix (`v1/`)
 
-- **왜**: 캐시 무효화 통합. 자산 갱신 결로 prefix 올려서 일괄 무효화 가능 (브라우저·CDN 캐시 1년 TTL 결로 결 박을 수 있음). 채팅 업로드(`uploads/`)는 별도 prefix(immutable URL 결로 캐시 무효화 무관)
+- **왜**: 캐시 무효화 통합. 자산 갱신 시 prefix를 올려서 일괄 무효화 가능 (브라우저·CDN 캐시 1년 TTL을 안전하게 박을 수 있음). 채팅 업로드(`uploads/`)는 별도 prefix (immutable URL이라 캐시 무효화 무관)
 - **대안**:
   - 평탄 구조 (`/audio/ambient/...`) — 단순. 다만 캐시 무효화 어려움 (개별 객체 invalidation 필요)
 - **빈틈**: v1 → v2 전환 시 코드(env var)·CD(sync target prefix)·도큐 동시 갱신 필요. 자동화 안 되면 누락 위험
 - **재검토 트리거**: 첫 prefix 전환 시 절차 정형화 / 자산 종류 늘어남 (운영 복잡도 측정)
 
-### D6. [헥사고날 경계] BGM = `BgmManager.ts` 신규 (AmbientSoundManager 결로 통합 X)
+### D6. [헥사고날 경계] BGM = `BgmManager.ts` 신규 (AmbientSoundManager와 통합 X)
 
-- **왜**: 환경음(자연음, 위치 기반)과 BGM(곡, scene 기반)은 책임이 다름. 위치 모델(`SoundPositionModel`)은 환경음 결로만, BGM은 scene 별 single track. 통합 시 `calculateVolume`이 두 도메인 알아야 함 (단일 책임 위반)
+> **2026-05-18 갱신 (Step 2 진행 중)**: 사용자 의도 확인 결과 **BGM = 환경음 4종**으로 확정. 추가 곡 없음. 본 결정은 폐기 — `AmbientSoundManager`만 살리고 별도 매니저 만들지 않음. 기록 보존 (왜 처음에 분리하려 했는지 의도 흔적).
+
+- **왜 (폐기 전 원래 의도)**: 환경음(자연음, 위치 기반)과 BGM(곡, scene 기반)은 책임이 다름. 위치 모델(`SoundPositionModel`)은 환경음 전용, BGM은 scene별 single track. 통합 시 `calculateVolume`이 두 도메인을 알아야 함 (단일 책임 위반)
 - **대안**:
-  - `AmbientSoundManager`에 BGM zone 추가 — 매니저 1개. 다만 책임 섞임, 곡 vs 자연음 동작 차이(crossfade·loop·license) 결로 결로 결로 결로 결로
-- **빈틈**: Howler.js 인스턴스 2개 결로 메모리·audio pool 결로 결로 결로 결로 결로 결로. `Howler.html5PoolSize = 30` 기존 설정 결로 결로 결로 (`AmbientSoundManager.ts:39` 참조)
-- **재검토 트리거**: BGM 곡 수 늘어남 (5곡 이상) / scene 별 BGM 분기 결로 결로 결로 (현재 마을·도서관 동일 곡)
+  - `AmbientSoundManager`에 BGM zone 추가 — 매니저 1개. 다만 책임 섞임, 곡 vs 자연음 동작 차이(crossfade·loop·license)가 한 클래스에 들어가야 함
+- **빈틈**: Howler.js 인스턴스 2개로 늘어나면 메모리·audio pool 압박. `Howler.html5PoolSize = 30` 기존 설정 내에서 흡수 가능 (`AmbientSoundManager.ts:39` 참조)
+- **재검토 트리거**: BGM 곡 수 늘어남 (5곡 이상) / scene별 BGM 분기 요구 발생 (현재 마을·도서관 동일 곡)
 
 ## 5. Tasks (= Steps)
 
@@ -126,7 +128,7 @@ last-updated: 2026-05-17
 
 | Step | 내용 | 의존 | 예상 변경 영역 | 이슈 | PR |
 |------|------|------|---------------|------|-----|
-| 1 | AWS S3 버킷 생성 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + ADR 박음 | — | `docs/architecture/decisions/{NNN}-s3-asset-hosting.md` (신규), AWS 콘솔 (수동) | #89 | (작업 시 채움) |
+| 1 | AWS S3 버킷 생성 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + ADR 박음 | — | `docs/architecture/decisions/009-s3-asset-hosting.md` (신규), AWS 콘솔 (수동) | #89 | #96 |
 | 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·`.env.local` 분리 + `.gitignore` 정리 + 루트 `package-lock.json` commit | step 1 | `frontend/src/three/audio/sound-config.ts`, `frontend/.env*`, `frontend/.gitignore`, 루트 `package-lock.json` | #89 | ... |
 | 3 | GitHub Actions workflow 신규 (`frontend/assets/` 변경 감지 → `aws s3 sync`) + OIDC IAM role 권한 추가 | step 1 | `.github/workflows/asset-sync.yml` (신규), AWS IAM (수동) | #89 | ... |
 | 4 | BGM mp3 S3 업로드 + `BgmManager.ts` 신규 + VillageScene 통합 + D11 가드(≤0.3) + LICENSE.md 갱신 | step 2, 3 | `frontend/src/three/audio/BgmManager.ts` (신규), `frontend/src/three/audio/sound-config.ts`, `frontend/src/three/scenes/VillageScene.ts`, `frontend/public/assets/LICENSE.md` | #89 | ... |
@@ -135,22 +137,22 @@ last-updated: 2026-05-17
 
 > 이게 통과하면 spec 종료. track 파일의 `§0.5 Acceptance Criteria` 와 1:1 매핑.
 
-- [ ] S3 버킷 생성 + public read 정책 + CORS 결로 `ghworld.co` origin 허용 확인 (AWS 콘솔 + curl 결로 검증)
-- [ ] frontend 빌드 시 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수 결로 S3 URL 주입 확인 (`npm run build` + 결과 결로 fetch URL 확인)
-- [ ] dev `npm run dev` 결로 환경음 4종 + BGM 정상 재생 (사용자 결로 청취 검증)
-- [ ] prod 배포 후 운영 환경(`ghworld.co`)에서 환경음 4종 + BGM 정상 재생 (현재 무음 해결 — 사용자 결로 청취 검증)
-- [ ] GitHub Actions workflow 결로 `frontend/assets/` 변경 → S3 sync 자동 실행 확인 (workflow run 로그 결로)
-- [ ] BGM 음량 ≤ 0.3 (D11 가드) 코드 강제 확인 (`BgmManager.ts` 결로 상수 + 단위 테스트 결로)
-- [ ] LICENSE.md 결로 BGM 곡 출처·라이선스 명시
+- [ ] S3 버킷 생성 + public read 정책 (`v1/*` 한정) + CORS의 `ghworld.co` origin 허용 확인 (AWS 콘솔 + curl로 검증)
+- [ ] frontend 빌드 시 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수로 S3 URL 주입 확인 (`npm run build` 결과의 fetch URL 확인)
+- [ ] dev `npm run dev`에서 환경음 4종 정상 재생 (사용자 청취 검증)
+- [ ] prod 배포 후 운영 환경(`ghworld.co`)에서 환경음 4종 정상 재생 (현재 무음 해결 — 사용자 청취 검증)
+- [ ] GitHub Actions workflow가 `frontend/assets/` 변경 시 S3 sync 자동 실행 확인 (workflow run 로그)
+- [ ] 환경음 D11 음량 가드 (≤ 0.3) 코드 강제 확인 (기존 `AmbientSoundManager` + `sound-config.ts`의 maxVolume 상수)
+- [ ] LICENSE.md에 환경음 4곡 출처·라이선스 명시
 - [ ] 루트 `package-lock.json` commit 확인 (husky 재현성)
 - [ ] 학습노트 51 (R2 vs S3 ADR + versioned prefix) + 52 (frontend 자산 외부화 패턴) 작성 완료
 
 ## 7. References
 
-- 트랙 파일: [track-s3-media.md](../../handover/track-s3-media.md) (`/track-start` 결로 신규 작성)
-- 관련 wiki: [frontend/asset-guide.md](../../wiki/frontend/asset-guide.md) (에셋 소스·라이선스·호스팅 정책), [infra/hooks-automation.md](../../wiki/infra/hooks-automation.md) (CD 자동화 결로)
-- 관련 learning: [37-cd-pipeline-design.md](../../learning/37-cd-pipeline-design.md) (기존 OIDC CD 파이프라인 기반), [78-next-three-howler-dev-memory-diagnosis.md](../../learning/78-next-three-howler-dev-memory-diagnosis.md) (Howler.js 결로 dev 메모리 결로 — BGM 추가 시 memory budget 주의)
-- 관련 ADR: `docs/architecture/decisions/{NNN}-s3-asset-hosting.md` (Step 1 결로 신규 박을 예정)
+- 트랙 파일: [track-s3-media.md](../../handover/track-s3-media.md) (`/track-start` 산출물)
+- 관련 wiki: [frontend/asset-guide.md](../../wiki/frontend/asset-guide.md) (에셋 소스·라이선스·호스팅 정책), [infra/hooks-automation.md](../../wiki/infra/hooks-automation.md) (CD 자동화 정책)
+- 관련 learning: [37-cd-pipeline-design.md](../../learning/37-cd-pipeline-design.md) (기존 OIDC CD 파이프라인 기반), [78-next-three-howler-dev-memory-diagnosis.md](../../learning/78-next-three-howler-dev-memory-diagnosis.md) (Howler.js dev 메모리 진단 — 자산 늘어날 때 memory budget 주의)
+- 관련 ADR: [009-s3-asset-hosting.md](../../architecture/decisions/009-s3-asset-hosting.md) (Step 1 산출물)
 - 외부 자료:
   - AWS S3 CORS 설정: https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html
   - GitHub Actions OIDC + AWS IAM: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
@@ -162,4 +164,5 @@ last-updated: 2026-05-17
 
 | 날짜 | 변경 |
 |------|------|
-| 2026-05-17 | 초안 작성 (사용자 결정 4단계 사이클 — R2 vs S3 트레이드오프 결로 S3 통일 + raw URL + dev/prod 외부 + CD 자동 + versioned prefix). decisions 6축 미리 박음 결로 Comprehension Gate 자동 통과 의도 |
+| 2026-05-17 | 초안 작성 (사용자 결정 4단계 사이클 — R2 vs S3 트레이드오프 끝에 S3 통일 + raw URL + dev/prod 외부 + CD 자동 + versioned prefix). decisions 6축 미리 박음으로 Comprehension Gate 자동 통과 의도 |
+| 2026-05-18 | D6 (BgmManager 분리) 폐기 — BGM = 환경음 4종으로 확정, 별도 매니저 없음. 기록 보존. Verification에서 BGM 관련 항목 환경음으로 통합 |


### PR DESCRIPTION
## Summary

새 트랙 `s3-media` 시작. Step 1 — AWS S3 인프라 박힘 + ADR 009 결로 결정·운영 매뉴얼·빈틈 결로 박음. 코드 변경 0, 문서·spec·ADR만.

- **spec** `docs/specs/features/s3-media.md` 신규 — decisions 6축 미리 박음 (D1 S3 vs R2 / D2 raw URL / D3 dev·prod 외부 / D4 CD 자동 / D5 versioned prefix / D6 BgmManager 분리) → Comprehension Gate 자동 통과
- **track** `docs/handover/track-s3-media.md` 신규 — Acceptance Criteria 8개 + 로드맵 4 step + 충돌 위험 파일 표
- **handover INDEX** 활성 표에 `s3-media` 추가 (병렬 진행 — `harden-village-ops` 와 영역 분리), 보류 표에서 제거
- **ADR 009** `docs/architecture/decisions/009-s3-asset-hosting.md` 신규 — S3 통일 + versioned prefix 결정 + 운영 매뉴얼 (Block Public Access · Bucket Policy · CORS · IAM JSON 박음)

## AWS 콘솔 작업 (완료)

- 버킷 `gohyang-s3-buket-20260514` (ap-northeast-2)
- Block Public Access — 정책 관련 2개만 해제
- Bucket Policy — `v1/*` public read
- CORS — `ghworld.co` + `www.ghworld.co` + `localhost:3000` origin 허용
- mp3 4종 `v1/audio/ambient/` 경로 업로드

## 다음

- Step 2 — frontend `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수화 → 운영 환경음 정상화
- Step 3 — GitHub Actions CD sync (`frontend/assets/` 변경 → S3 자동 sync)
- Step 4 — BGM mp3 + `BgmManager.ts` + D11 가드 (≤0.3)

## Test plan

- [ ] CodeRabbit / Codex 리뷰 통과
- [ ] markdownlint 통과 (pre-commit hook 결로 자동)
- [ ] spec / track / ADR 결로 모든 cross-link 동작 확인
- [ ] 머지 후 Step 2 브랜치 분기 가능 (main pull)

Closes part of #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * AWS S3 기반 정적 에셋 외부 호스팅에 대한 아키텍처 결정 문서 추가
  * S3 환경음 및 배경음악 외부 호스팅 트랙 및 구현 사양 문서 추가
  * AWS S3 버킷 설정, CORS, IAM 권한 및 에셋 업데이트 절차에 대한 운영 가이드 문서화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkzkzhzj/ChatAppProject/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->