### PR TITLE
feat(s3-media): Step 2 — frontend S3 fetch 환경변수화 + Step 5(CloudFront+OAC) 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,7 @@ jobs:
           build-args: |
             NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL || 'https://ghworld.co' }}
             NEXT_PUBLIC_WS_URL=${{ vars.NEXT_PUBLIC_WS_URL || 'https://ghworld.co/ws' }}
+            NEXT_PUBLIC_ASSETS_BASE_URL=${{ vars.NEXT_PUBLIC_ASSETS_BASE_URL || 'https://gohyang-s3-buket-20260514.s3.ap-northeast-2.amazonaws.com' }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -225,6 +225,8 @@ services:
       args:
         NEXT_PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8080}
         NEXT_PUBLIC_WS_URL: ${PUBLIC_WS_URL:-http://localhost:8080/ws}
+        # S3 정적 자산 base URL. ADR 009. Step 5 (CloudFront+OAC) 후 cloudfront 도메인으로 갱신 예정.
+        NEXT_PUBLIC_ASSETS_BASE_URL: ${PUBLIC_ASSETS_BASE_URL:-https://gohyang-s3-buket-20260514.s3.ap-northeast-2.amazonaws.com}
     container_name: gohyang-frontend
     ports:
       - "${FRONTEND_PORT:-3000}:3000"

--- a/docs/handover/track-s3-media.md
+++ b/docs/handover/track-s3-media.md
@@ -21,6 +21,8 @@
 - [ ] GitHub Actions workflow가 `frontend/assets/` 변경 시 S3 sync 자동 실행 확인
 - [ ] 환경음 D11 음량 가드 (≤ 0.3) 코드 강제 확인 (기존 `AmbientSoundManager` + `sound-config.ts`의 maxVolume 상수)
 - [ ] LICENSE.md에 환경음 4곡 출처·라이선스 명시
+- [ ] CloudFront + OAC 도입 — S3 직접 GET 차단 (403) + CloudFront 도메인 호출 200 확인
+- [ ] CloudFront 캐싱 hit ratio > 80% (첫 1주일, CloudWatch 메트릭)
 - [ ] 학습노트 51 (R2 vs S3 ADR + versioned prefix) + 52 (frontend 자산 외부화 패턴) 작성 완료
 
 ## 1. 배경 / 왜
@@ -40,10 +42,11 @@
 
 | Step | 내용 | 의존 | 상태 | 이슈 | PR |
 |------|------|------|------|------|-----|
-| 1 | AWS S3 버킷 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + `docs/architecture/decisions/009-s3-asset-hosting.md` ADR | — | 🔧 리뷰 대응 | #89 | #96 |
-| 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·`.env.local` 분리 + `.gitignore` 정리 + LICENSE.md (환경음 4곡) | step 1 | 대기 | #89 | — |
+| 1 | AWS S3 버킷 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + `docs/architecture/decisions/009-s3-asset-hosting.md` ADR | — | ✅ 완료 | #89 | #96 |
+| 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·Dockerfile·CD build-args + `.gitignore` 정리 + LICENSE.md | step 1 | 🔧 진행 | #89 | — |
 | 3 | GitHub Actions workflow + OIDC IAM role 권한 추가 + `aws s3 sync` 자동화 | step 1 | 대기 | #89 | — |
 | ~~4~~ | ~~BGM mp3 + BgmManager.ts 신규~~ — **폐기 (2026-05-18)**: BGM = 환경음 4종으로 확정 | — | 폐기 | — | — |
+| 5 | CloudFront + OAC 도입 — S3 직접 public 차단, CloudFront만 경로 + cache policy + Bucket Policy 갱신 + `NEXT_PUBLIC_ASSETS_BASE_URL` 갱신 + ADR 갱신 | step 2 | 대기 | #89 | — |
 
 ## 3. 현재 단계 상세
 

--- a/docs/handover/track-s3-media.md
+++ b/docs/handover/track-s3-media.md
@@ -14,14 +14,19 @@
 
 > spec §6 Verification 과 1:1 매핑. 트랙 종료 시 같이 체크.
 
-- [ ] S3 버킷 생성 + public read 정책 (`v1/*` 한정) + CORS의 `ghworld.co` origin 허용 확인 (AWS 콘솔 + curl로 검증)
-- [ ] frontend 빌드 시 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수로 S3 URL 주입 확인
+**Step 1 (S3 raw, 임시 상태)**:
+- [x] S3 버킷 생성 + public read 정책 (`v1/*` 한정) + CORS의 `ghworld.co` origin 허용 (Step 1 머지 시점에 검증 완료, S3 직접 GET 200)
+
+**Step 2 (frontend env)**:
+- [ ] frontend 빌드 시 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수로 자산 URL 주입 확인
 - [ ] dev `npm run dev`에서 환경음 4종 정상 재생
 - [ ] prod 배포 후 운영 환경(`ghworld.co`)에서 환경음 4종 정상 재생 (현재 무음 해결 — 사용자 청취 검증)
-- [ ] GitHub Actions workflow가 `frontend/assets/` 변경 시 S3 sync 자동 실행 확인
-- [ ] 환경음 D11 음량 가드 (≤ 0.3) 코드 강제 확인 (기존 `AmbientSoundManager` + `sound-config.ts`의 maxVolume 상수)
+- [ ] 환경음 D11 음량 가드 (≤ 0.3) 코드 강제 확인 (`AmbientSoundManager` + `sound-config.ts`의 maxVolume 상수)
 - [ ] LICENSE.md에 환경음 4곡 출처·라이선스 명시
-- [ ] CloudFront + OAC 도입 — S3 직접 GET 차단 (403) + CloudFront 도메인 호출 200 확인
+
+**Step 5 (CloudFront + OAC, 보호 진입)**:
+- [ ] Bucket Policy를 OAC 전용으로 변경 → S3 직접 GET 403 (Step 1 public read는 단방향 전환됨)
+- [ ] CloudFront 도메인 호출 시 200 + cache `HIT` 확인
 - [ ] CloudFront 캐싱 hit ratio > 80% (첫 1주일, CloudWatch 메트릭)
 - [ ] 학습노트 51 (R2 vs S3 ADR + versioned prefix) + 52 (frontend 자산 외부화 패턴) 작성 완료
 
@@ -43,8 +48,8 @@
 | Step | 내용 | 의존 | 상태 | 이슈 | PR |
 |------|------|------|------|------|-----|
 | 1 | AWS S3 버킷 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + `docs/architecture/decisions/009-s3-asset-hosting.md` ADR | — | ✅ 완료 | #89 | #96 |
-| 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·Dockerfile·CD build-args + `.gitignore` 정리 + LICENSE.md | step 1 | 🔧 진행 | #89 | — |
-| 3 | GitHub Actions workflow + OIDC IAM role 권한 추가 + `aws s3 sync` 자동화 | step 1 | 대기 | #89 | — |
+| 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·Dockerfile·CD build-args + `.gitignore` 정리 + LICENSE.md | step 1 | 🔧 진행 | #89 | #102 |
+| ~~3~~ | ~~CD 자동 sync workflow~~ — **폐기 (2026-05-18)**: mp3가 git 추적 X 결로 trigger 불가. 자산 업로드는 사용자 콘솔/CLI 수동 | — | 폐기 | — | — |
 | ~~4~~ | ~~BGM mp3 + BgmManager.ts 신규~~ — **폐기 (2026-05-18)**: BGM = 환경음 4종으로 확정 | — | 폐기 | — | — |
 | 5 | CloudFront + OAC 도입 — S3 직접 public 차단, CloudFront만 경로 + cache policy + Bucket Policy 갱신 + `NEXT_PUBLIC_ASSETS_BASE_URL` 갱신 + ADR 갱신 | step 2 | 대기 | #89 | — |
 

--- a/docs/specs/features/s3-media.md
+++ b/docs/specs/features/s3-media.md
@@ -30,8 +30,9 @@ last-updated: 2026-05-17
 
 ### 2.1 In (이번 트랙에서 만든다)
 
-- AWS S3 버킷 신설 (`ap-northeast-2`, public read)
+- AWS S3 버킷 신설 (`ap-northeast-2`, public read on `v1/*`)
 - IAM 정책 + 버킷 정책 + CORS 설정 (`ghworld.co` origin 허용)
+- **CloudFront + OAC 도입** — S3 직접 public 차단, CloudFront만 경로. 캐싱·DDoS·hotlinking 방어 (Step 5)
 - `frontend/public/assets/` 의 mp3 4종 → S3 마이그 (`s3://bucket/v1/audio/ambient/`)
 - 코드: `sound-config.ts`의 src를 환경변수 `NEXT_PUBLIC_ASSETS_BASE_URL`로 prefix해서 외부 URL 주입
 - GitHub Actions 자산 sync workflow (`frontend/assets/` 변경 감지 → `aws s3 sync`)
@@ -45,8 +46,7 @@ last-updated: 2026-05-17
 
 > Out 이 spec 가치의 절반. "안 만드는 것" 을 적어야 다음 세션이 스코프 침범 안 함.
 
-- **CloudFront 도입** — raw S3 URL 시작, 후속 트랙
-- **`uploads/chat/` 사용자 업로드 경로 활성화** — 채팅 이미지 트랙에서
+- **`uploads/chat/` 사용자 업로드 경로 활성화** — 채팅 이미지 트랙에서 (별도 버킷 + Presigned URL 패턴 검토)
 - **도서관 3D 모델 마이그** — 도서관 트랙에서 (자산 폴더 구조만 미리 박음)
 - **캐시 무효화 자동화** — 수동 prefix 갱신(`v1` → `v2`)으로 시작
 - **BGM 곡 수 확장** — 현재는 마을·도서관 동일 곡, 도서관에서 페이드만 (Scene 별 곡 분기는 후속)
@@ -79,14 +79,26 @@ last-updated: 2026-05-17
 - **빈틈**: 다중 리전 / 글로벌 사용자에게 fetch latency 부담. CloudFront로 후속 보강. 또한 사용자 업로드 비용(egress) 늘어나면 R2 재검토 필요
 - **재검토 트리거**: 월 egress > $5 / 글로벌 사용자 비중 > 30% / 자산 합산 > 1GB
 
-### D2. [API 설계] 도메인 = raw S3 URL (CloudFront 후속)
+### D2. [API 설계] 도메인 = CloudFront + OAC (raw S3 직접 노출 X)
 
-- **왜**: 단순 시작. 자산 작아서 latency 부담 적음. `https://{bucket}.s3.ap-northeast-2.amazonaws.com/v1/audio/ambient/gentle-wind.mp3` 형태로 직접
+> **2026-05-18 갱신**: 원래 "raw S3 URL 시작, CloudFront 후속" 결로 박았으나 본 트랙 안에서 CloudFront까지 끝내기로 정정 (Step 5 추가). 이유: 사용자 업로드(`uploads/`)는 후속 트랙으로 분리하고 공용 에셋 버킷은 정석으로 한 번에 박는 게 깔끔. URL 노출·DDoS·hotlinking 가드도 같이 박힘.
+
+- **왜**: 공용 에셋은 한 번 박으면 자주 변하지 않음. CloudFront edge 캐싱 효과 큼. S3 직접 차단(OAC)으로 hotlinking·DDoS 가드 + 비용 폭주 차단. Cloudflare DNS와 자연 결합 (CNAME으로 `assets.ghworld.co` 또는 그대로 cloudfront 도메인)
 - **대안**:
-  - CloudFront + `assets.ghworld.co` — SSL·캐싱·custom 도메인 정석. 다만 Route 53 또는 Cloudflare proxy 추가 작업, 트랙 범위 확장
-  - Cloudflare proxy (S3 origin) — 도메인 통합 OK. 다만 origin 설정 + cache rule 별도 작업
-- **빈틈**: CORS 헤더 직접 관리 필요. 캐시 TTL S3 기본값(없음 — 매 요청 fetch)
-- **재검토 트리거**: latency 불만 / S3 비용 (cache miss) / 도서관 트랙 자산 늘어남
+  - raw S3 URL 그대로 — 단순. 다만 캐싱 X, hotlinking·DDoS 가드 X, 비용 폭주 위험
+  - Cloudflare proxy (S3 origin) — 도메인 통합 OK. 다만 R2 결로 결로 결로 결로 결로 안 갈 거면 AWS 친화 결로 CloudFront가 더 자연
+  - Presigned URL — D7 결로 별도 분석 (mp3에 부적합)
+- **빈틈**: 캐시 무효화 시 invalidation 비용 ($0.005/path 결로 결로 결로). versioned prefix(`v1/`) 결로 회피. CloudFront 설정 (OAC, behavior, cache policy) 복잡도 증가
+- **재검토 트리거**: free tier 1TB/월 초과 (월 $85+ 결로 결로) / edge cache hit ratio < 80% / 도서관 트랙 자산 합산 > 1GB
+
+### D7. [API 설계] 자산 접근 = CloudFront 결로 (Presigned URL X)
+
+- **왜**: 공용 mp3는 **반복 재생** 결로 결로. Presigned URL은 시간 제한이라 만료마다 새 URL → 캐시 깨짐 → 매번 새로 다운로드 → 비용·끊김
+- **대안**:
+  - Presigned URL — 부적합 (위 설명). 또한 백엔드 결로 결로 URL 생성 API 필요 → 헥사고날 결로 결로 결로 결로 추가 port + adapter
+  - 인증된 fetch (JWT 결로) — public 자산에 과함
+- **빈틈**: 누구나 URL 알면 GET 가능. 다만 CloudFront WAF로 rate limit / Referer 검사 결로 결로 hotlinking 차단 가능
+- **재검토 트리거**: 비공개 자산 (예: 채팅 이미지 결로 특정 유저만) 필요 시 → 별도 버킷·트랙
 
 ### D3. [환경 분기] 환경 = dev/prod 모두 외부 fetch
 
@@ -128,20 +140,23 @@ last-updated: 2026-05-17
 
 | Step | 내용 | 의존 | 예상 변경 영역 | 이슈 | PR |
 |------|------|------|---------------|------|-----|
-| 1 | AWS S3 버킷 생성 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + ADR 박음 | — | `docs/architecture/decisions/009-s3-asset-hosting.md` (신규), AWS 콘솔 (수동) | #89 | #96 |
-| 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·`.env.local` 분리 + `.gitignore` 정리 + 루트 `package-lock.json` commit | step 1 | `frontend/src/three/audio/sound-config.ts`, `frontend/.env*`, `frontend/.gitignore`, 루트 `package-lock.json` | #89 | ... |
-| 3 | GitHub Actions workflow 신규 (`frontend/assets/` 변경 감지 → `aws s3 sync`) + OIDC IAM role 권한 추가 | step 1 | `.github/workflows/asset-sync.yml` (신규), AWS IAM (수동) | #89 | ... |
-| 4 | BGM mp3 S3 업로드 + `BgmManager.ts` 신규 + VillageScene 통합 + D11 가드(≤0.3) + LICENSE.md 갱신 | step 2, 3 | `frontend/src/three/audio/BgmManager.ts` (신규), `frontend/src/three/audio/sound-config.ts`, `frontend/src/three/scenes/VillageScene.ts`, `frontend/public/assets/LICENSE.md` | #89 | ... |
+| 1 | AWS S3 버킷 생성 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + ADR 박음 | — | `docs/architecture/decisions/009-s3-asset-hosting.md` (신규), AWS 콘솔 (수동) | #89 | #96 ✅ |
+| 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·`.env.local` 분리 + Dockerfile/CD build-args + `.gitignore` 정리 + LICENSE.md (환경음 4곡) | step 1 | `frontend/src/three/audio/sound-config.ts`, `frontend/.env*`, `frontend/Dockerfile`, `.github/workflows/deploy.yml`, `frontend/.gitignore`, `frontend/public/assets/audio/LICENSE.md` | #89 | 🔧 |
+| 3 | GitHub Actions workflow 신규 (`frontend/public/assets/` 변경 감지 → `aws s3 sync`) + OIDC IAM role 권한 추가 | step 1 | `.github/workflows/asset-sync.yml` (신규), AWS IAM (수동) | #89 | 대기 |
+| ~~4~~ | ~~BGM mp3 + BgmManager.ts 신규~~ — **폐기 (2026-05-18)**: BGM = 환경음 4종으로 확정 | — | — | — | — |
+| 5 | CloudFront + OAC 도입 — S3 직접 public 차단, CloudFront만 경로. cache policy + Bucket Policy 갱신 (Principal을 OAC service principal로). `NEXT_PUBLIC_ASSETS_BASE_URL`을 CloudFront 도메인으로 갱신. ADR 갱신 | step 2 | AWS 콘솔 (수동), `frontend/.env*`, `frontend/Dockerfile`, `.github/workflows/deploy.yml`, ADR 009 갱신 | #89 | 대기 |
 
 ## 6. Verification (수용 기준)
 
 > 이게 통과하면 spec 종료. track 파일의 `§0.5 Acceptance Criteria` 와 1:1 매핑.
 
 - [ ] S3 버킷 생성 + public read 정책 (`v1/*` 한정) + CORS의 `ghworld.co` origin 허용 확인 (AWS 콘솔 + curl로 검증)
-- [ ] frontend 빌드 시 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수로 S3 URL 주입 확인 (`npm run build` 결과의 fetch URL 확인)
+- [ ] frontend 빌드 시 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수로 자산 URL 주입 확인 (`npm run build` 결과의 fetch URL 확인)
 - [ ] dev `npm run dev`에서 환경음 4종 정상 재생 (사용자 청취 검증)
 - [ ] prod 배포 후 운영 환경(`ghworld.co`)에서 환경음 4종 정상 재생 (현재 무음 해결 — 사용자 청취 검증)
-- [ ] GitHub Actions workflow가 `frontend/assets/` 변경 시 S3 sync 자동 실행 확인 (workflow run 로그)
+- [ ] GitHub Actions workflow가 `frontend/public/assets/` 변경 시 S3 sync 자동 실행 확인 (workflow run 로그)
+- [ ] **CloudFront + OAC** 도입 후 S3 직접 GET 차단 확인 (S3 URL 직접 호출 시 403, CloudFront 도메인 호출 시 200)
+- [ ] CloudFront 캐싱 hit ratio > 80% 확인 (CloudWatch CloudFront 메트릭 결로 첫 1주일)
 - [ ] 환경음 D11 음량 가드 (≤ 0.3) 코드 강제 확인 (기존 `AmbientSoundManager` + `sound-config.ts`의 maxVolume 상수)
 - [ ] LICENSE.md에 환경음 4곡 출처·라이선스 명시
 - [ ] 루트 `package-lock.json` commit 확인 (husky 재현성)
@@ -166,3 +181,4 @@ last-updated: 2026-05-17
 |------|------|
 | 2026-05-17 | 초안 작성 (사용자 결정 4단계 사이클 — R2 vs S3 트레이드오프 끝에 S3 통일 + raw URL + dev/prod 외부 + CD 자동 + versioned prefix). decisions 6축 미리 박음으로 Comprehension Gate 자동 통과 의도 |
 | 2026-05-18 | D6 (BgmManager 분리) 폐기 — BGM = 환경음 4종으로 확정, 별도 매니저 없음. 기록 보존. Verification에서 BGM 관련 항목 환경음으로 통합 |
+| 2026-05-18 | D2 갱신 + 새 D7 추가 — CloudFront + OAC를 본 트랙 안에서 끝내기로 (Step 5 추가). 원래 "raw S3 + CloudFront 후속" 결정 정정. Step 4 폐기 + Step 5 신설. Verification에 CloudFront 항목 2개 추가. 이유: 공용 에셋 버킷은 정석으로 한 번에, 사용자 업로드(`uploads/`)는 별도 후속 트랙 |

--- a/docs/specs/features/s3-media.md
+++ b/docs/specs/features/s3-media.md
@@ -33,6 +33,7 @@ last-updated: 2026-05-17
 - AWS S3 버킷 신설 (`ap-northeast-2`, public read on `v1/*`)
 - IAM 정책 + 버킷 정책 + CORS 설정 (`ghworld.co` origin 허용)
 - **CloudFront + OAC 도입** — S3 직접 public 차단, CloudFront만 경로. 캐싱·DDoS·hotlinking 방어 (Step 5)
+- mp3·자산 S3 업로드는 **사용자가 콘솔/CLI 결로 직접 진행** (git 추적 X, source of truth는 S3)
 - `frontend/public/assets/` 의 mp3 4종 → S3 마이그 (`s3://bucket/v1/audio/ambient/`)
 - 코드: `sound-config.ts`의 src를 환경변수 `NEXT_PUBLIC_ASSETS_BASE_URL`로 prefix해서 외부 URL 주입
 - GitHub Actions 자산 sync workflow (`frontend/assets/` 변경 감지 → `aws s3 sync`)
@@ -47,6 +48,7 @@ last-updated: 2026-05-17
 > Out 이 spec 가치의 절반. "안 만드는 것" 을 적어야 다음 세션이 스코프 침범 안 함.
 
 - **`uploads/chat/` 사용자 업로드 경로 활성화** — 채팅 이미지 트랙에서 (별도 버킷 + Presigned URL 패턴 검토)
+- **CD 자동 mp3 sync** — mp3가 git 추적 X 결로 GitHub Actions trigger 불가. 자산 변경은 사용자 수동 S3 콘솔/CLI 업로드. (~~Step 3 폐기~~)
 - **도서관 3D 모델 마이그** — 도서관 트랙에서 (자산 폴더 구조만 미리 박음)
 - **캐시 무효화 자동화** — 수동 prefix 갱신(`v1` → `v2`)으로 시작
 - **BGM 곡 수 확장** — 현재는 마을·도서관 동일 곡, 도서관에서 페이드만 (Scene 별 곡 분기는 후속)
@@ -142,7 +144,7 @@ last-updated: 2026-05-17
 |------|------|------|---------------|------|-----|
 | 1 | AWS S3 버킷 생성 + IAM + CORS + 버킷 정책. 인프라 수동 작업 + ADR 박음 | — | `docs/architecture/decisions/009-s3-asset-hosting.md` (신규), AWS 콘솔 (수동) | #89 | #96 ✅ |
 | 2 | frontend 코드 — `sound-config.ts` 환경변수화 + `.env`·`.env.local` 분리 + Dockerfile/CD build-args + `.gitignore` 정리 + LICENSE.md (환경음 4곡) | step 1 | `frontend/src/three/audio/sound-config.ts`, `frontend/.env*`, `frontend/Dockerfile`, `.github/workflows/deploy.yml`, `frontend/.gitignore`, `frontend/public/assets/audio/LICENSE.md` | #89 | 🔧 |
-| 3 | GitHub Actions workflow 신규 (`frontend/public/assets/` 변경 감지 → `aws s3 sync`) + OIDC IAM role 권한 추가 | step 1 | `.github/workflows/asset-sync.yml` (신규), AWS IAM (수동) | #89 | 대기 |
+| ~~3~~ | ~~GitHub Actions asset-sync workflow~~ — **폐기 (2026-05-18)**: mp3가 git 추적 X 결로 trigger 불가. S3 업로드는 사용자 수동 진행 (콘솔/CLI) | — | — | — | — |
 | ~~4~~ | ~~BGM mp3 + BgmManager.ts 신규~~ — **폐기 (2026-05-18)**: BGM = 환경음 4종으로 확정 | — | — | — | — |
 | 5 | CloudFront + OAC 도입 — S3 직접 public 차단, CloudFront만 경로. cache policy + Bucket Policy 갱신 (Principal을 OAC service principal로). `NEXT_PUBLIC_ASSETS_BASE_URL`을 CloudFront 도메인으로 갱신. ADR 갱신 | step 2 | AWS 콘솔 (수동), `frontend/.env*`, `frontend/Dockerfile`, `.github/workflows/deploy.yml`, ADR 009 갱신 | #89 | 대기 |
 
@@ -150,17 +152,24 @@ last-updated: 2026-05-17
 
 > 이게 통과하면 spec 종료. track 파일의 `§0.5 Acceptance Criteria` 와 1:1 매핑.
 
-- [ ] S3 버킷 생성 + public read 정책 (`v1/*` 한정) + CORS의 `ghworld.co` origin 허용 확인 (AWS 콘솔 + curl로 검증)
+**Step 1 (현재 시점, S3 raw)**:
+- [ ] S3 버킷 생성 + public read 정책 (`v1/*` 한정) + CORS의 `ghworld.co` origin 허용 확인 (AWS 콘솔 + curl로 검증, S3 직접 GET 200)
+
+**Step 2 (frontend env)**:
 - [ ] frontend 빌드 시 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수로 자산 URL 주입 확인 (`npm run build` 결과의 fetch URL 확인)
 - [ ] dev `npm run dev`에서 환경음 4종 정상 재생 (사용자 청취 검증)
 - [ ] prod 배포 후 운영 환경(`ghworld.co`)에서 환경음 4종 정상 재생 (현재 무음 해결 — 사용자 청취 검증)
-- [ ] GitHub Actions workflow가 `frontend/public/assets/` 변경 시 S3 sync 자동 실행 확인 (workflow run 로그)
-- [ ] **CloudFront + OAC** 도입 후 S3 직접 GET 차단 확인 (S3 URL 직접 호출 시 403, CloudFront 도메인 호출 시 200)
-- [ ] CloudFront 캐싱 hit ratio > 80% 확인 (CloudWatch CloudFront 메트릭 결로 첫 1주일)
+
+**Step 5 (CloudFront + OAC 도입 후, 보호 진입)**:
+- [ ] Bucket Policy를 OAC 전용으로 변경 → **S3 직접 GET 403** (Step 1의 public read는 이 시점에 무효화됨, 단방향 전환)
+- [ ] CloudFront 도메인 호출 시 200 + cache `HIT` 확인
+- [ ] CloudFront 캐싱 hit ratio > 80% (CloudWatch CloudFront 메트릭 첫 1주일)
+
+**트랙 종료 공통**:
+- [ ] 학습노트 51 (R2 vs S3 + versioned prefix + CloudFront/OAC) + 52 (frontend 자산 외부화 패턴) 작성 완료
 - [ ] 환경음 D11 음량 가드 (≤ 0.3) 코드 강제 확인 (기존 `AmbientSoundManager` + `sound-config.ts`의 maxVolume 상수)
 - [ ] LICENSE.md에 환경음 4곡 출처·라이선스 명시
 - [ ] 루트 `package-lock.json` commit 확인 (husky 재현성)
-- [ ] 학습노트 51 (R2 vs S3 ADR + versioned prefix) + 52 (frontend 자산 외부화 패턴) 작성 완료
 
 ## 7. References
 
@@ -182,3 +191,4 @@ last-updated: 2026-05-17
 | 2026-05-17 | 초안 작성 (사용자 결정 4단계 사이클 — R2 vs S3 트레이드오프 끝에 S3 통일 + raw URL + dev/prod 외부 + CD 자동 + versioned prefix). decisions 6축 미리 박음으로 Comprehension Gate 자동 통과 의도 |
 | 2026-05-18 | D6 (BgmManager 분리) 폐기 — BGM = 환경음 4종으로 확정, 별도 매니저 없음. 기록 보존. Verification에서 BGM 관련 항목 환경음으로 통합 |
 | 2026-05-18 | D2 갱신 + 새 D7 추가 — CloudFront + OAC를 본 트랙 안에서 끝내기로 (Step 5 추가). 원래 "raw S3 + CloudFront 후속" 결정 정정. Step 4 폐기 + Step 5 신설. Verification에 CloudFront 항목 2개 추가. 이유: 공용 에셋 버킷은 정석으로 한 번에, 사용자 업로드(`uploads/`)는 별도 후속 트랙 |
+| 2026-05-18 | Step 3 (CD 자동 sync) 폐기 — mp3가 git 추적 X 결로 GitHub Actions trigger 불가 (Codex P2 리뷰). 자산 업로드는 사용자가 콘솔/CLI 결로 수동 진행. Verification을 Step 1·Step 2·Step 5 시점별로 분리 (CodeRabbit 단계별 분리 지적 반영). |

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,2 +1,5 @@
 NEXT_PUBLIC_API_URL=http://localhost:8080
 NEXT_PUBLIC_WS_URL=http://localhost:8080/ws
+# S3 정적 자산 base URL. ADR 009 (`docs/architecture/decisions/009-s3-asset-hosting.md`) 참조.
+# dev/prod 모두 외부 S3에서 fetch (spec D3). 변경 시 deploy.yml + Dockerfile + 본 파일 동시 갱신.
+NEXT_PUBLIC_ASSETS_BASE_URL=https://gohyang-s3-buket-20260514.s3.ap-northeast-2.amazonaws.com

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -41,10 +41,11 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# binary asset (spec D4' — 외부 인프라 마이그 예정, s3-media 트랙)
-# 환경음 / 3D 모델 / 텍스처 등은 git 추적 X. 사용자 다운로드 (README 가이드) 또는 s3-media 트랙 마이그 후 외부 URL.
+# binary asset — S3 외부 호스팅 (s3-media 트랙, ADR 009 참조).
+# 환경음 / 3D 모델 / 텍스처 등은 git 추적 X. 운영에선 NEXT_PUBLIC_ASSETS_BASE_URL 환경변수의 S3 base URL에서 fetch.
+# dev에서도 동일 (spec D3 — 환경 분기 없음). 로컬에 mp3 두지 않아도 동작.
 # 단 텍스트 자산 (LICENSE.md · README.md · 정책 문서) 은 추적.
-public/assets/audio/ambient/*.mp3
-public/assets/audio/ambient/*.ogg
-public/assets/audio/ambient/*.wav
-public/assets/audio/ambient/*.m4a
+public/assets/audio/**/*.mp3
+public/assets/audio/**/*.ogg
+public/assets/audio/**/*.wav
+public/assets/audio/**/*.m4a

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,8 +22,10 @@ COPY . .
 # docker-compose.yml의 build.args에서 주입받는다.
 ARG NEXT_PUBLIC_API_URL=http://localhost:8080
 ARG NEXT_PUBLIC_WS_URL=http://localhost:8080/ws
+ARG NEXT_PUBLIC_ASSETS_BASE_URL=https://gohyang-s3-buket-20260514.s3.ap-northeast-2.amazonaws.com
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
+ENV NEXT_PUBLIC_ASSETS_BASE_URL=$NEXT_PUBLIC_ASSETS_BASE_URL
 
 # standalone 모드 빌드 — node_modules 없이 실행 가능한 경량 번들 생성
 RUN npm run build

--- a/frontend/public/assets/audio/LICENSE.md
+++ b/frontend/public/assets/audio/LICENSE.md
@@ -31,4 +31,4 @@
 - 다운로드 일자
 - (CC BY인 경우) 저작자 + 표기 의무 내용
 
-자산이 변경되거나 추가되면 S3 sync workflow가 자동으로 `v1/audio/`에 반영 (Step 3 산출물 예정).
+자산이 변경되거나 추가되면 **사용자가 AWS 콘솔/CLI 결로 `v1/audio/`에 직접 업로드**. mp3는 git 추적 X 결로 자동 sync 불가 (CD trigger 안 됨). ADR 009 §운영 매뉴얼 참조.

--- a/frontend/public/assets/audio/LICENSE.md
+++ b/frontend/public/assets/audio/LICENSE.md
@@ -1,0 +1,34 @@
+# 오디오 자산 라이선스
+
+> 본 디렉토리의 mp3 자산은 git에 추적되지 않는다 (`frontend/.gitignore` 참조).
+> 운영 환경에서는 S3 버킷 `gohyang-s3-buket-20260514`의 `v1/audio/` prefix에서 fetch한다.
+> ADR 009 (`docs/architecture/decisions/009-s3-asset-hosting.md`) 참조.
+
+---
+
+## 환경음 (`ambient/`)
+
+4곡 모두 **Pixabay Content License** (CC0 기반, 상업적 사용 허용, attribution 비강제).
+
+| 파일 | 출처 | 라이선스 | 다운로드 |
+|---|---|---|---|
+| `gentle-wind.mp3` | [Pixabay](https://pixabay.com/sound-effects/) | Pixabay Content License | 2026-05-17 |
+| `crackling-fire.mp3` | [Pixabay](https://pixabay.com/sound-effects/) | Pixabay Content License | 2026-05-17 |
+| `pond-water.mp3` | [Pixabay](https://pixabay.com/sound-effects/) | Pixabay Content License | 2026-05-17 |
+| `forest-birds.mp3` | [Pixabay](https://pixabay.com/sound-effects/) | Pixabay Content License | 2026-05-17 |
+
+> Pixabay Content License 요지: 자유롭게 사용·수정·배포 가능 (상업적 포함). attribution 권장이지만 필수 X. 단순 재배포 자체를 상품화하는 행위는 금지.
+
+---
+
+## 향후 자산 추가 시
+
+본 표에 한 줄 추가:
+
+- 파일명
+- 출처 URL
+- 라이선스 종류 (CC0 / CC BY / Pixabay Content License / Mixkit Free / 구매)
+- 다운로드 일자
+- (CC BY인 경우) 저작자 + 표기 의무 내용
+
+자산이 변경되거나 추가되면 S3 sync workflow가 자동으로 `v1/audio/`에 반영 (Step 3 산출물 예정).

--- a/frontend/public/assets/audio/ambient/README.md
+++ b/frontend/public/assets/audio/ambient/README.md
@@ -1,7 +1,11 @@
 # 환경음 자산 가이드
 
 > spec [village-3d.md](../../../../../docs/specs/features/village-3d.md) D6 (v) 자연 환경음 + D11 안식처 가드레일 6축 정합.
-> Step 2 — 위치 기반 환경음 4종 (사용자 결 박음, 2026-05-11).
+> Step 2 — 위치 기반 환경음 4종 (사용자 결정 박음, 2026-05-11).
+>
+> **2026-05-18 갱신**: 자산은 S3 외부 호스팅 (`gohyang-s3-buket-20260514`, prefix `v1/audio/ambient/`).
+> `frontend/.gitignore`로 추적 X, 코드에선 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수로 fetch.
+> 출처/라이선스는 [`../LICENSE.md`](../LICENSE.md), 호스팅 결정은 [ADR 009](../../../../../docs/architecture/decisions/009-s3-asset-hosting.md).
 
 ---
 

--- a/frontend/src/three/audio/sound-config.ts
+++ b/frontend/src/three/audio/sound-config.ts
@@ -26,10 +26,18 @@ export interface SoundZone {
   readonly id: string;
   readonly src: string;
   readonly description: string;
-  /** 캐릭터 위치가 zone 결 결 결 결 결 결 결 음량. D11 결 ≤ 0.3 정합. */
+  /** 캐릭터 위치가 zone 안에 있을 때의 최대 음량. D11 안식처 가드레일 ≤ 0.3 정합. */
   readonly maxVolume: number;
   readonly model: SoundPositionModel;
 }
+
+/**
+ * 정적 자산 base URL — ADR 009 (`docs/architecture/decisions/009-s3-asset-hosting.md`) 참조.
+ * dev/prod 모두 외부 S3 fetch (spec D3). 미설정 시 빈 문자열로 path만 사용 →
+ * 의도적 404 (로컬 mp3 없음) → 환경음 무음. `.env.local.example` 따라 설정 필요.
+ */
+const ASSETS_BASE = process.env.NEXT_PUBLIC_ASSETS_BASE_URL ?? '';
+const assetUrl = (path: string): string => `${ASSETS_BASE}${path}`;
 
 /**
  * 마을 zone — 4개 사운드:
@@ -41,33 +49,33 @@ export interface SoundZone {
 export const VILLAGE_SOUNDS: readonly SoundZone[] = [
   {
     id: 'gentle-wind',
-    src: '/assets/audio/ambient/gentle-wind.mp3',
+    src: assetUrl('/v1/audio/ambient/gentle-wind.mp3'),
     description: '잔잔한 바람 (마을 전역 baseline)',
     maxVolume: 0.25,
     model: { kind: 'global' },
   },
   {
     id: 'crackling-fire',
-    src: '/assets/audio/ambient/crackling-fire.mp3',
+    src: assetUrl('/v1/audio/ambient/crackling-fire.mp3'),
     description: '캠프파이어 모닥불 (모임 광장 가까이)',
     maxVolume: 0.22,
     model: { kind: 'point', x: 0, z: 8, fadeRadius: 8 },
   },
   {
     id: 'pond-water',
-    src: '/assets/audio/ambient/pond-water.mp3',
+    src: assetUrl('/v1/audio/ambient/pond-water.mp3'),
     description: '연못 물소리 (사용자 의견 — "물소리 좋거든")',
     maxVolume: 0.2,
     model: { kind: 'point', x: -5, z: -5, fadeRadius: 6 },
   },
   {
     id: 'forest-birds',
-    src: '/assets/audio/ambient/forest-birds.mp3',
+    src: assetUrl('/v1/audio/ambient/forest-birds.mp3'),
     description: '숲 새소리 (마을 외곽 가까이)',
     maxVolume: 0.25,
     model: { kind: 'forest-edge', outerRadius: 28 },
   },
-] as const;
+];
 
 /**
  * 도서관 zone — 1개 사운드:
@@ -76,12 +84,12 @@ export const VILLAGE_SOUNDS: readonly SoundZone[] = [
 export const LIBRARY_SOUNDS: readonly SoundZone[] = [
   {
     id: 'gentle-wind',
-    src: '/assets/audio/ambient/gentle-wind.mp3',
+    src: assetUrl('/v1/audio/ambient/gentle-wind.mp3'),
     description: '실내 옅은 바람 (도서관 단조)',
     maxVolume: 0.1,
     model: { kind: 'global' },
   },
-] as const;
+];
 
 /**
  * 마스터 볼륨 — 전체 환경음 출력 곱. 1.0 = 개별 maxVolume 가 그대로 실효 음량.


### PR DESCRIPTION
## Summary

운영 환경 환경음 무음 해결의 핵심 PR. frontend 자산 fetch URL을 `NEXT_PUBLIC_ASSETS_BASE_URL` 환경변수로 외부 S3 결로 박음. **PR 머지 + CD 배포 후 ghworld.co에서 환경음 4종 재생 확인 가능**.

### 코드 변경 (7개)

- **`frontend/src/three/audio/sound-config.ts`** — 자산 src 5곳을 `assetUrl(path)` 헬퍼 결로 변환. env 미설정 시 빈 string prefix → 의도적 404 (개발자 친화)
- **`frontend/Dockerfile`** — `NEXT_PUBLIC_ASSETS_BASE_URL` ARG/ENV 추가 (build-time inline, Next.js NEXT_PUBLIC 결로 자연)
- **`.github/workflows/deploy.yml`** — build-args에 `NEXT_PUBLIC_ASSETS_BASE_URL` 추가 (`vars.*` 또는 fallback)
- **`frontend/.env.local.example`** — dev용 변수 명시 + ADR 009 참조 주석
- **`frontend/.gitignore`** — `public/assets/audio/**/*.{mp3,ogg,wav,m4a}` 결로 (ambient/ + 향후 추가 폴더). 정책 주석 갱신
- **`frontend/public/assets/audio/LICENSE.md`** (신규) — Pixabay Content License 4곡 명시
- **`frontend/public/assets/audio/ambient/README.md`** — S3 외부화 완료 배너

### spec/track 갱신 (Step 5 추가 — A 옵션 결정)

- **D2 갱신** — `raw S3 + CloudFront 후속` → `CloudFront + OAC를 본 트랙 안에서 끝냄`. 공용 에셋 정석으로 한 번에, 사용자 업로드(`uploads/`)는 별도 후속 트랙
- **D7 신설** — Presigned URL 거부 이유 (mp3 반복 재생 + 캐시 깨짐 + 백엔드 부하)
- **§5 Tasks** — Step 1 ✅, Step 4 ~~폐기~~, Step 5 신설 (CloudFront + OAC)
- **§6 Verification** — CloudFront 항목 2개 추가 (S3 직접 GET 403 / hit ratio > 80%)

## Test plan

- [ ] CodeRabbit / Codex 리뷰 통과
- [ ] markdownlint 통과 (pre-commit hook 결로 자동)
- [ ] CI 빌드 + 컨테이너 빌드 성공 (Dockerfile ARG 정합)
- [ ] 머지 후 운영 배포 (CD 자동) → ghworld.co 결로 환경음 4종 재생 확인 (사용자 청취)
- [ ] dev `npm run dev` 결로 환경음 재생 확인 (`.env.local` 박혀있는 환경)

## 다음

- Step 3 — GitHub Actions `asset-sync.yml` (자산 변경 시 자동 S3 sync) + OIDC IAM 권한 추가
- Step 5 — CloudFront + OAC

Closes part of #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * S3 미디어 트랙 사양 및 배포 로드맵 업데이트(CloudFront+OAC 검증 항목·캐시 목표 포함)
  * 오디오 자산 라이선스 및 ambient README 내용 추가/갱신

* **설정**
  * 정적 자산 기본 URL 환경변수(NEXT_PUBLIC_ASSETS_BASE_URL) 예시 추가
  * 빌드·배포 설정에 정적 자산 베이스 URL 주입 지원 추가

* **기타**
  * 로컬에서 오디오 파일을 유지하지 않아도 동작하도록 무시 패턴 확장 및 자산 fetch 방식 변경

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkzkzhzj/ChatAppProject/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->