### PR TITLE
feat(s3-media): Step 5 — CloudFront + OAC distribution 도입

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,7 +120,7 @@ jobs:
           build-args: |
             NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL || 'https://ghworld.co' }}
             NEXT_PUBLIC_WS_URL=${{ vars.NEXT_PUBLIC_WS_URL || 'https://ghworld.co/ws' }}
-            NEXT_PUBLIC_ASSETS_BASE_URL=${{ vars.NEXT_PUBLIC_ASSETS_BASE_URL || 'https://gohyang-s3-buket-20260514.s3.ap-northeast-2.amazonaws.com' }}
+            NEXT_PUBLIC_ASSETS_BASE_URL=${{ vars.NEXT_PUBLIC_ASSETS_BASE_URL || 'https://d9btdaowoaya0.cloudfront.net' }}
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -225,8 +225,8 @@ services:
       args:
         NEXT_PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8080}
         NEXT_PUBLIC_WS_URL: ${PUBLIC_WS_URL:-http://localhost:8080/ws}
-        # S3 정적 자산 base URL. ADR 009. Step 5 (CloudFront+OAC) 후 cloudfront 도메인으로 갱신 예정.
-        NEXT_PUBLIC_ASSETS_BASE_URL: ${PUBLIC_ASSETS_BASE_URL:-https://gohyang-s3-buket-20260514.s3.ap-northeast-2.amazonaws.com}
+        # CloudFront 정적 자산 base URL (Step 5 — OAC). ADR 009.
+        NEXT_PUBLIC_ASSETS_BASE_URL: ${PUBLIC_ASSETS_BASE_URL:-https://d9btdaowoaya0.cloudfront.net}
     container_name: gohyang-frontend
     ports:
       - "${FRONTEND_PORT:-3000}:3000"

--- a/docs/architecture/decisions/009-s3-asset-hosting.md
+++ b/docs/architecture/decisions/009-s3-asset-hosting.md
@@ -32,7 +32,8 @@
 |---|---|
 | 버킷 이름 | `gohyang-s3-buket-20260514` |
 | 리전 | `ap-northeast-2` (서울) |
-| URL 형식 | `https://gohyang-s3-buket-20260514.s3.ap-northeast-2.amazonaws.com/v1/{path}` |
+| CloudFront distribution | `d9btdaowoaya0.cloudfront.net` (Step 5, 2026-05-19) |
+| 클라 URL 형식 | `https://d9btdaowoaya0.cloudfront.net/v1/{path}` |
 | 정적 prefix | `v1/audio/{ambient,bgm}/`, `v1/models/`, `v1/textures/` (확장 예정) |
 | 사용자 업로드 prefix (후속) | `uploads/chat/{userId}/{messageId}.{ext}` — 비공개 유지 |
 
@@ -68,7 +69,9 @@
 
 저장 시 "confirm" 입력.
 
-### 2. Bucket Policy (public read on `v1/*`)
+### 2. Bucket Policy
+
+**Step 1 시점 (S3 raw, 임시 — 무중단 마이그 결로 결로 유지)**:
 
 Permissions → "Bucket policy" → Edit → 붙여넣기 → Save:
 
@@ -88,6 +91,41 @@ Permissions → "Bucket policy" → Edit → 붙여넣기 → Save:
 ```
 
 `v1/` prefix만 public read. `uploads/` 같은 사용자 업로드 경로는 비공개 유지 — 후속 트랙에서 sigv4 또는 presigned URL로 접근 제공.
+
+**Step 5 시점 (CloudFront + OAC, 최종)**:
+
+S3 직접 GET 차단 + CloudFront만 접근. CloudFront distribution 생성 시 콘솔이 자동 생성한 정책 결로 결로:
+
+```json
+{
+  "Version": "2008-10-17",
+  "Id": "PolicyForCloudFrontPrivateContent",
+  "Statement": [
+    {
+      "Sid": "AllowCloudFrontServicePrincipal",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudfront.amazonaws.com"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::gohyang-s3-buket-20260514/*",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceArn": "arn:aws:cloudfront::{ACCOUNT_ID}:distribution/{DISTRIBUTION_ID}"
+        }
+      }
+    }
+  ]
+}
+```
+
+→ S3 직접 GET 403. CloudFront 결로만 200.
+
+**무중단 마이그 순서**:
+1. CloudFront distribution 생성 (Bucket Policy는 Step 1 결로 유지 — public read)
+2. 코드 결로 `NEXT_PUBLIC_ASSETS_BASE_URL` → CloudFront 도메인 갱신 + 운영 배포
+3. 운영 결로 CloudFront 경로 환경음 동작 확인
+4. Bucket Policy 결로 Step 5 버전 결로 교체 (S3 직접 차단)
 
 ### 3. CORS (브라우저 cross-origin fetch 허용)
 

--- a/docs/architecture/decisions/009-s3-asset-hosting.md
+++ b/docs/architecture/decisions/009-s3-asset-hosting.md
@@ -23,7 +23,7 @@
 ### 핵심 결정 3축
 
 1. **스토리지 = AWS S3** (Cloudflare R2 X) — spec D1
-2. **도메인 = raw S3 URL** (CloudFront 후속) — spec D2
+2. **클라 fetch = CloudFront + OAC** (S3 직접 노출 X, edge 캐싱 + DDoS 흡수 + Layer 3-4 Shield Standard) — spec D2. 갱신 2026-05-19: 원래 "raw S3 URL + CloudFront 후속"이었으나 Step 5에서 본 트랙으로 흡수
 3. **폴더 = versioned prefix** (`v1/`) — spec D5
 
 ### 인프라 사양
@@ -71,7 +71,7 @@
 
 ### 2. Bucket Policy
 
-**Step 1 시점 (S3 raw, 임시 — 무중단 마이그 결로 결로 유지)**:
+**Step 1 시점 (S3 raw, 임시 — 무중단 마이그 동안 유지)**:
 
 Permissions → "Bucket policy" → Edit → 붙여넣기 → Save:
 
@@ -94,7 +94,7 @@ Permissions → "Bucket policy" → Edit → 붙여넣기 → Save:
 
 **Step 5 시점 (CloudFront + OAC, 최종)**:
 
-S3 직접 GET 차단 + CloudFront만 접근. CloudFront distribution 생성 시 콘솔이 자동 생성한 정책 결로 결로:
+S3 직접 GET 차단 + CloudFront만 접근. CloudFront distribution 생성 시 콘솔이 자동 생성한 정책:
 
 ```json
 {
@@ -119,13 +119,13 @@ S3 직접 GET 차단 + CloudFront만 접근. CloudFront distribution 생성 시 
 }
 ```
 
-→ S3 직접 GET 403. CloudFront 결로만 200.
+→ S3 직접 GET 403. CloudFront 경유만 200.
 
 **무중단 마이그 순서**:
-1. CloudFront distribution 생성 (Bucket Policy는 Step 1 결로 유지 — public read)
-2. 코드 결로 `NEXT_PUBLIC_ASSETS_BASE_URL` → CloudFront 도메인 갱신 + 운영 배포
-3. 운영 결로 CloudFront 경로 환경음 동작 확인
-4. Bucket Policy 결로 Step 5 버전 결로 교체 (S3 직접 차단)
+1. CloudFront distribution 생성 (Bucket Policy는 Step 1 버전 유지 — public read)
+2. 코드의 `NEXT_PUBLIC_ASSETS_BASE_URL`을 CloudFront 도메인으로 갱신 + 운영 배포
+3. 운영에서 CloudFront 경로 환경음 동작 확인
+4. Bucket Policy를 Step 5 버전으로 교체 (S3 직접 차단)
 
 ### 3. CORS (브라우저 cross-origin fetch 허용)
 

--- a/docs/architecture/decisions/009-s3-asset-hosting.md
+++ b/docs/architecture/decisions/009-s3-asset-hosting.md
@@ -108,7 +108,7 @@ S3 직접 GET 차단 + CloudFront만 접근. CloudFront distribution 생성 시 
         "Service": "cloudfront.amazonaws.com"
       },
       "Action": "s3:GetObject",
-      "Resource": "arn:aws:s3:::gohyang-s3-buket-20260514/*",
+      "Resource": "arn:aws:s3:::gohyang-s3-buket-20260514/v1/*",
       "Condition": {
         "StringEquals": {
           "AWS:SourceArn": "arn:aws:cloudfront::{ACCOUNT_ID}:distribution/{DISTRIBUTION_ID}"

--- a/docs/specs/features/s3-media.md
+++ b/docs/specs/features/s3-media.md
@@ -4,7 +4,7 @@ track: s3-media
 issue: "#89"
 status: draft
 created: 2026-05-17
-last-updated: 2026-05-17
+last-updated: 2026-05-19
 ---
 
 # 정적 에셋 외부 호스팅 인프라 (S3 + CD 자동 sync + BGM 운영 정상화)

--- a/docs/specs/features/s3-media.md
+++ b/docs/specs/features/s3-media.md
@@ -192,3 +192,4 @@ last-updated: 2026-05-17
 | 2026-05-18 | D6 (BgmManager 분리) 폐기 — BGM = 환경음 4종으로 확정, 별도 매니저 없음. 기록 보존. Verification에서 BGM 관련 항목 환경음으로 통합 |
 | 2026-05-18 | D2 갱신 + 새 D7 추가 — CloudFront + OAC를 본 트랙 안에서 끝내기로 (Step 5 추가). 원래 "raw S3 + CloudFront 후속" 결정 정정. Step 4 폐기 + Step 5 신설. Verification에 CloudFront 항목 2개 추가. 이유: 공용 에셋 버킷은 정석으로 한 번에, 사용자 업로드(`uploads/`)는 별도 후속 트랙 |
 | 2026-05-18 | Step 3 (CD 자동 sync) 폐기 — mp3가 git 추적 X 결로 GitHub Actions trigger 불가 (Codex P2 리뷰). 자산 업로드는 사용자가 콘솔/CLI 결로 수동 진행. Verification을 Step 1·Step 2·Step 5 시점별로 분리 (CodeRabbit 단계별 분리 지적 반영). |
+| 2026-05-19 | Step 5 진행 — CloudFront distribution `d9btdaowoaya0.cloudfront.net` 생성, OAC 결합. fallback 4곳 (Dockerfile / deploy.yml / docker-compose.yml / .env.local.example) CloudFront 도메인으로 갱신. Bucket Policy 결로 OAC 교체는 운영 검증 후 별도 (무중단 마이그). |

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_API_URL=http://localhost:8080
 NEXT_PUBLIC_WS_URL=http://localhost:8080/ws
-# S3 정적 자산 base URL. ADR 009 (`docs/architecture/decisions/009-s3-asset-hosting.md`) 참조.
-# dev/prod 모두 외부 S3에서 fetch (spec D3). 변경 시 deploy.yml + Dockerfile + 본 파일 동시 갱신.
-NEXT_PUBLIC_ASSETS_BASE_URL=https://gohyang-s3-buket-20260514.s3.ap-northeast-2.amazonaws.com
+# CloudFront 정적 자산 base URL (Step 5 — OAC). ADR 009 참조.
+# dev/prod 모두 외부 CloudFront에서 fetch (spec D3). 변경 시 deploy.yml + Dockerfile + docker-compose.yml 동시 갱신.
+NEXT_PUBLIC_ASSETS_BASE_URL=https://d9btdaowoaya0.cloudfront.net

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,7 +22,7 @@ COPY . .
 # docker-compose.yml의 build.args에서 주입받는다.
 ARG NEXT_PUBLIC_API_URL=http://localhost:8080
 ARG NEXT_PUBLIC_WS_URL=http://localhost:8080/ws
-ARG NEXT_PUBLIC_ASSETS_BASE_URL=https://gohyang-s3-buket-20260514.s3.ap-northeast-2.amazonaws.com
+ARG NEXT_PUBLIC_ASSETS_BASE_URL=https://d9btdaowoaya0.cloudfront.net
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_WS_URL=$NEXT_PUBLIC_WS_URL
 ENV NEXT_PUBLIC_ASSETS_BASE_URL=$NEXT_PUBLIC_ASSETS_BASE_URL


### PR DESCRIPTION
## Summary

CloudFront distribution `d9btdaowoaya0.cloudfront.net` 생성 + OAC 결합. 자산 fetch URL을 S3 직접 → CloudFront 경유로 전환.

### 코드 변경 (4곳 fallback)
- `frontend/Dockerfile` — ARG default
- `.github/workflows/deploy.yml` — build-args
- `deploy/docker-compose.yml` — frontend.build.args
- `frontend/.env.local.example` + 로컬 `.env.local`

### 문서
- ADR 009 — 인프라 사양 표 + Bucket Policy Step 1 vs Step 5 버전 + 무중단 마이그 절차

## 검증
- `curl -I https://d9btdaowoaya0.cloudfront.net/v1/audio/ambient/gentle-wind.mp3` → 200 OK 확인 (X-Cache Miss 첫 호출)

## 머지 후 남은 작업 (콘솔 1단계)
머지 → 운영 배포 → ghworld.co 결로 CloudFront 경로 환경음 동작 확인 → Bucket Policy 결로 OAC 전용 교체 (S3 직접 GET 차단). ADR 009 §2 Step 5 버전 JSON 결로 그대로 박으면 끝.

Closes part of #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 정적 자산 호스팅이 S3 직접 제공에서 CloudFront 기반으로 전환되었습니다.
  * 배포·개발 환경의 자산 URL 설정이 CloudFront 도메인으로 업데이트되었습니다.

* **Documentation**
  * 운영 매뉴얼 및 아키텍처 문서에 CloudFront 전환 절차(무중단 마이그레이션 포함)와 정책 변경 안내가 추가/갱신되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkzkzhzj/ChatAppProject/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->