### PR TITLE
fix(audio): 환경음 mp3 → m4a — iOS WebKit decodeAudioData fix

### DIFF
--- a/docs/handover/track-village-3d-audio-improvements.md
+++ b/docs/handover/track-village-3d-audio-improvements.md
@@ -132,15 +132,37 @@ cd frontend && npm run dev
 | `frontend/src/three/audio/sound-config.ts` | 2 | 본 트랙 전용 (선택 — 변경 없을 가능성 ↑) |
 | `frontend/src/components/ui/AudioControls.tsx` | 2 | 신규 (충돌 X) |
 
-## 5. 다음 세션 착수 전 확인 사항
+## 5. 현재 작업 위치 — m4a 전환 (2026-05-25)
 
-- main 동기화 (`harden-village-ops` 트랙 머지 시 변경 사항 점검)
-- iOS·Android 결로 운영 검증 — 사용자 단말 결로 직접 확인 (Step 2 결로)
+### 5.1 가설 확정 완료
+
+- **gentle-wind.m4a cheap test 성공** (2026-05-25): iOS Chrome + cloudflared로 슬라이더 정상 반응 확인
+- 근본 원인 확정: iOS WebKit `decodeAudioData()`가 mp3 디코딩 실패 → Howler html5 폴백 → iOS `HTMLMediaElement.volume` read-only → 슬라이더·위치 무력
+- 해결: m4a(AAC) = Apple 네이티브 포맷 → `decodeAudioData()` 성공 → Web Audio 모드 유지 → GainNode 음량 제어 정상
+
+### 5.2 S3 CORS 개선 (이번 세션)
+
+- `https://*.trycloudflare.com` 추가 → 배포 없이 cloudflared로 iOS 검증 가능해짐
+- 이전에 배포 필수였던 이유: cloudflared 도메인이 CORS 미허용 → Web Audio XHR 차단 → html5 폴백 → m4a든 mp3든 같은 증상
+
+### 5.3 남은 작업 (현재 위치)
+
+- [x] gentle-wind.m4a 변환 + 업로드 + 코드 변경 + iOS 검증
+- [x] sound-config.ts 4종 전체 m4a 전환 + 위치 기반 복원 (코드 완료)
+- [ ] 나머지 3종 m4a 변환 + S3 업로드 (사용자 단말 ffmpeg 실행 대기)
+- [ ] iOS 전체 4종 검증 (cloudflared로 가능)
+- [ ] PR 생성 + 머지
+
+### 5.4 환경 정보
+
+- `aws cli` v2.34.34, `ffmpeg` 설치 완료
+- S3 버킷: `gohyang-s3-buket-20260514`, prefix `v1/audio/ambient/`
+- CloudFront: `d9btdaowoaya0.cloudfront.net`
+- S3 CORS AllowedOrigins: `ghworld.co`, `www.ghworld.co`, `localhost:3000`, `*.trycloudflare.com`
 
 ## 6. 보류 메모
 
 - **🟢 진단 결박 제거 완료** (2026-05-23) — §3 항목 6 결박 history. 운영 배포 결박 검증 결박만 남음
-- 자산 재인코딩 — Web Audio 디코딩 실패 발견 시 별건
 - 단축키 (`M` 같은 키보드) — 데스크탑 결로 후속 의제
 - 개별 환경음 음량 조절 — 4종 각각 슬라이더 X (마스터 1개만)
 - BGM/SFX 분리 채널 — 향후 BGM 채널 추가 시 별건

--- a/docs/handover/track-village-3d-audio-improvements.md
+++ b/docs/handover/track-village-3d-audio-improvements.md
@@ -147,11 +147,12 @@ cd frontend && npm run dev
 
 ### 5.3 남은 작업 (현재 위치)
 
-- [x] gentle-wind.m4a 변환 + 업로드 + 코드 변경 + iOS 검증
-- [x] sound-config.ts 4종 전체 m4a 전환 + 위치 기반 복원 (코드 완료)
-- [ ] 나머지 3종 m4a 변환 + S3 업로드 (사용자 단말 ffmpeg 실행 대기)
+- [x] sound-config.ts 경로 변경 (4종 + 도서관 1종, .mp3 → .m4a)
+- [x] gentle-wind.m4a 변환 + S3 업로드 + iOS 검증
+- [x] crackling-fire, pond-water, forest-birds m4a 변환 + S3 업로드 (ffmpeg -c:a aac -b:a 128k)
+- [x] PR #112 생성
 - [ ] iOS 전체 4종 검증 (cloudflared로 가능)
-- [ ] PR 생성 + 머지
+- [ ] PR 머지 + 운영 배포
 
 ### 5.4 환경 정보
 

--- a/frontend/src/three/audio/sound-config.ts
+++ b/frontend/src/three/audio/sound-config.ts
@@ -49,28 +49,28 @@ const assetUrl = (path: string): string => `${ASSETS_BASE}${path}`;
 export const VILLAGE_SOUNDS: readonly SoundZone[] = [
   {
     id: 'gentle-wind',
-    src: assetUrl('/v1/audio/ambient/gentle-wind.mp3'),
+    src: assetUrl('/v1/audio/ambient/gentle-wind.m4a'),
     description: '잔잔한 바람 (마을 전역 baseline)',
     maxVolume: 0.25,
     model: { kind: 'global' },
   },
   {
     id: 'crackling-fire',
-    src: assetUrl('/v1/audio/ambient/crackling-fire.mp3'),
+    src: assetUrl('/v1/audio/ambient/crackling-fire.m4a'),
     description: '캠프파이어 모닥불 (모임 광장 가까이)',
     maxVolume: 0.22,
     model: { kind: 'point', x: 0, z: 8, fadeRadius: 8 },
   },
   {
     id: 'pond-water',
-    src: assetUrl('/v1/audio/ambient/pond-water.mp3'),
+    src: assetUrl('/v1/audio/ambient/pond-water.m4a'),
     description: '연못 물소리 (사용자 의견 — "물소리 좋거든")',
     maxVolume: 0.2,
     model: { kind: 'point', x: -5, z: -5, fadeRadius: 6 },
   },
   {
     id: 'forest-birds',
-    src: assetUrl('/v1/audio/ambient/forest-birds.mp3'),
+    src: assetUrl('/v1/audio/ambient/forest-birds.m4a'),
     description: '숲 새소리 (마을 외곽 가까이)',
     maxVolume: 0.25,
     model: { kind: 'forest-edge', outerRadius: 28 },
@@ -84,7 +84,7 @@ export const VILLAGE_SOUNDS: readonly SoundZone[] = [
 export const LIBRARY_SOUNDS: readonly SoundZone[] = [
   {
     id: 'gentle-wind',
-    src: assetUrl('/v1/audio/ambient/gentle-wind.mp3'),
+    src: assetUrl('/v1/audio/ambient/gentle-wind.m4a'),
     description: '실내 옅은 바람 (도서관 단조)',
     maxVolume: 0.1,
     model: { kind: 'global' },


### PR DESCRIPTION
## Summary

- iOS WebKit `decodeAudioData()`가 mp3 디코딩 실패 → Howler html5 폴백 → `HTMLMediaElement.volume` read-only → 슬라이더·위치 기반 음량 무력화
- 환경음 4종 mp3 → m4a(AAC) 전환으로 Web Audio 모드 유지 → GainNode 음량 제어 정상화
- S3 CORS에 `https://*.trycloudflare.com` 추가 (개발 시 배포 없이 iOS 검증 가능)

## Changes

- `sound-config.ts`: 5곳 `.mp3` → `.m4a` (VILLAGE_SOUNDS 4종 + LIBRARY_SOUNDS 1종)
- S3: m4a 자산 4종 업로드 (`ffmpeg -c:a aac -b:a 128k`)
- S3 CORS: `AllowedOrigins`에 `https://*.trycloudflare.com` 추가

## Test plan

- [x] gentle-wind.m4a cheap test — iOS Chrome + cloudflared로 슬라이더 반응 확인
- [ ] 4종 전체 iOS 검증 (슬라이더 + 위치 기반 음량)
- [x] TypeScript, ESLint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 오디오 파일 형식을 업데이트하여 iOS 장치에서 오디오 재생 호환성을 개선했습니다.
  * 마을 및 도서관의 배경 음향 처리를 최적화하여 안정적인 음량 제어를 복원했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkzkzhzj/ChatAppProject/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->