### PR TITLE
Fix PR 130 review feedback

### DIFF
--- a/backend/src/main/java/com/maeum/gohyang/communication/adapter/in/web/ChatRoomController.java
+++ b/backend/src/main/java/com/maeum/gohyang/communication/adapter/in/web/ChatRoomController.java
@@ -74,8 +74,7 @@ public class ChatRoomController {
 
     private MessageResponse toMessageResponse(Message message, Map<Long, Participant> participantMap) {
         Participant participant = participantMap.get(message.getParticipantId());
-        long senderId = (participant != null && participant.getUserId() != null)
-                ? participant.getUserId() : message.getParticipantId();
+        Long senderId = participant != null ? participant.getUserId() : null;
         return MessageResponse.from(message, senderId);
     }
 }

--- a/backend/src/main/java/com/maeum/gohyang/communication/adapter/in/web/MessageResponse.java
+++ b/backend/src/main/java/com/maeum/gohyang/communication/adapter/in/web/MessageResponse.java
@@ -3,17 +3,19 @@ package com.maeum.gohyang.communication.adapter.in.web;
 import java.time.Instant;
 import java.util.UUID;
 
+import org.jspecify.annotations.Nullable;
+
 import com.maeum.gohyang.communication.domain.Message;
 
 public record MessageResponse(
         UUID id,
         long participantId,
-        long senderId,
+        @Nullable Long senderId,
         String body,
         Instant createdAt
 ) {
 
-    public static MessageResponse from(Message message, long senderId) {
+    public static MessageResponse from(Message message, @Nullable Long senderId) {
         return new MessageResponse(
                 message.getId(),
                 message.getParticipantId(),

--- a/backend/src/main/java/com/maeum/gohyang/communication/domain/Participant.java
+++ b/backend/src/main/java/com/maeum/gohyang/communication/domain/Participant.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 public class Participant {
 
+    public static final String DEFAULT_DISPLAY_NAME = "resident";
+
     private final Long id;
     private final Long userId;
     private final Long chatRoomId;
@@ -27,7 +29,7 @@ public class Participant {
     }
 
     public static Participant newMember(long userId, long chatRoomId) {
-        return new Participant(null, userId, chatRoomId, "resident",
+        return new Participant(null, userId, chatRoomId, DEFAULT_DISPLAY_NAME,
                 ParticipantRole.MEMBER, EntryType.PROXIMITY, LocalDateTime.now(), null);
     }
 

--- a/backend/src/main/java/com/maeum/gohyang/confession/adapter/in/web/LibraryLibrarianController.java
+++ b/backend/src/main/java/com/maeum/gohyang/confession/adapter/in/web/LibraryLibrarianController.java
@@ -3,13 +3,16 @@ package com.maeum.gohyang.confession.adapter.in.web;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.maeum.gohyang.confession.application.port.in.ListLibrarianSimilarConfessionsUseCase;
 import com.maeum.gohyang.confession.domain.ConfessionBookshelf;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -21,13 +24,26 @@ public class LibraryLibrarianController {
 
     @GetMapping("/similar-confessions")
     public List<ConfessionSummaryResponse> listSimilarConfessions(
-            @RequestParam(required = false) ConfessionBookshelf bookshelf,
-            @RequestParam(defaultValue = "5") int limit) {
+            @Valid @ModelAttribute ListSimilarConfessionsRequest request) {
         return listLibrarianSimilarConfessionsUseCase.execute(
-                        new ListLibrarianSimilarConfessionsUseCase.Query(bookshelf, limit)
+                        request.toQuery()
                 )
                 .stream()
                 .map(ConfessionSummaryResponse::from)
                 .toList();
+    }
+
+    public record ListSimilarConfessionsRequest(
+            ConfessionBookshelf bookshelf,
+            @Min(1) @Max(20) Integer limit
+    ) {
+        private static final int DEFAULT_LIMIT = 5;
+
+        ListLibrarianSimilarConfessionsUseCase.Query toQuery() {
+            return new ListLibrarianSimilarConfessionsUseCase.Query(
+                    bookshelf,
+                    limit != null ? limit : DEFAULT_LIMIT
+            );
+        }
     }
 }

--- a/backend/src/test/java/com/maeum/gohyang/communication/adapter/in/web/MessageResponseTest.java
+++ b/backend/src/test/java/com/maeum/gohyang/communication/adapter/in/web/MessageResponseTest.java
@@ -1,0 +1,33 @@
+package com.maeum.gohyang.communication.adapter.in.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.maeum.gohyang.communication.domain.Message;
+import com.maeum.gohyang.communication.domain.MessageType;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+class MessageResponseTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder().build();
+
+    @Test
+    void 메시지_응답은_senderId를_포함하고_senderType을_노출하지_않는다() {
+        UUID id = UUID.randomUUID();
+        Instant createdAt = Instant.parse("2026-04-08T12:00:00Z");
+        Message message = Message.restore(id, 1L, 10L, "hello", MessageType.TEXT, createdAt);
+        MessageResponse response = MessageResponse.from(message, 42L);
+
+        JsonNode json = objectMapper.valueToTree(response);
+
+        assertThat(json.get("senderId").asLong()).isEqualTo(42L);
+        assertThat(json.get("senderType")).isNull();
+    }
+}

--- a/backend/src/test/java/com/maeum/gohyang/communication/adapter/in/websocket/v2/protocol/OutboundFrameJsonTest.java
+++ b/backend/src/test/java/com/maeum/gohyang/communication/adapter/in/websocket/v2/protocol/OutboundFrameJsonTest.java
@@ -22,7 +22,7 @@ class OutboundFrameJsonTest {
     private final ObjectMapper objectMapper = JsonMapper.builder().build();
 
     @Test
-    void message_event_serializes_user_payload_without_sender_type() {
+    void 메시지_이벤트는_senderType_없이_사용자_페이로드를_직렬화한다() {
         UUID id = UUID.randomUUID();
         Instant createdAt = Instant.parse("2026-04-26T10:00:00Z");
         Message message = Message.restore(id, 42L, 99L, "hello", MessageType.TEXT, createdAt);
@@ -41,7 +41,7 @@ class OutboundFrameJsonTest {
     }
 
     @Test
-    void error_event_serializes_code_and_message() {
+    void 에러_이벤트는_코드와_메시지를_직렬화한다() {
         ErrorEvent event = ErrorEvent.of(CommunicationErrorCode.GUEST_CHAT_NOT_ALLOWED);
 
         JsonNode json = objectMapper.valueToTree(event);
@@ -53,7 +53,7 @@ class OutboundFrameJsonTest {
     }
 
     @Test
-    void position_update_event_serializes_position() {
+    void 위치_업데이트_이벤트는_좌표를_직렬화한다() {
         PositionUpdateEvent event = PositionUpdateEvent.of(1L, "user-101", "MEMBER", 100.5, 200.0);
 
         JsonNode json = objectMapper.valueToTree(event);
@@ -67,7 +67,7 @@ class OutboundFrameJsonTest {
     }
 
     @Test
-    void typing_update_event_serializes_typing_state() {
+    void 타이핑_업데이트_이벤트는_타이핑_상태를_직렬화한다() {
         TypingUpdateEvent event = TypingUpdateEvent.of(1L, "user-101", true);
 
         JsonNode json = objectMapper.valueToTree(event);
@@ -78,7 +78,7 @@ class OutboundFrameJsonTest {
     }
 
     @Test
-    void system_payload_has_null_sender_id() {
+    void 시스템_페이로드는_senderId가_null이다() {
         ChatMessagePayload payload = ChatMessagePayload.system("entered");
 
         assertThat(payload.senderId()).isNull();
@@ -87,7 +87,7 @@ class OutboundFrameJsonTest {
     }
 
     @Test
-    void pong_event_serializes_single_type_field() {
+    void PONG_이벤트는_type_필드만_직렬화한다() {
         PongEvent event = PongEvent.instance();
 
         JsonNode json = objectMapper.valueToTree(event);

--- a/backend/src/test/java/com/maeum/gohyang/communication/application/service/SendMessageServiceTest.java
+++ b/backend/src/test/java/com/maeum/gohyang/communication/application/service/SendMessageServiceTest.java
@@ -48,12 +48,12 @@ class SendMessageServiceTest {
     }
 
     @Nested
-    @DisplayName("success")
+    @DisplayName("성공")
     class Success {
 
         @Test
-        @DisplayName("plain mention-like text is saved as a normal user message")
-        void plain_mention_like_text_is_saved_as_normal_user_message() {
+        @DisplayName("멘션처럼 보이는 본문도 일반 사용자 메시지로 저장된다")
+        void 멘션처럼_보이는_본문도_일반_사용자_메시지로_저장된다() {
             String mentionBody = "@village-resident hello";
             given(loadParticipantPort.load(USER_ID, CHAT_ROOM_ID)).willReturn(Optional.of(userParticipant()));
             given(saveMessagePort.saveWithUser(any(Message.class), anyLong())).willAnswer(inv -> inv.getArgument(0));
@@ -65,8 +65,8 @@ class SendMessageServiceTest {
         }
 
         @Test
-        @DisplayName("participant is created automatically before sending a message")
-        void participant_is_created_automatically_before_sending_message() {
+        @DisplayName("메시지 전송 전 참여자가 자동 생성된다")
+        void 메시지_전송_전_참여자가_자동_생성된다() {
             given(loadParticipantPort.load(USER_ID, CHAT_ROOM_ID)).willReturn(Optional.empty());
             given(saveParticipantPort.save(any(Participant.class))).willReturn(userParticipant());
             given(saveMessagePort.saveWithUser(any(Message.class), anyLong())).willAnswer(inv -> inv.getArgument(0));
@@ -79,8 +79,8 @@ class SendMessageServiceTest {
         }
 
         @Test
-        @DisplayName("concurrent participant creation recovers by reloading")
-        void concurrent_participant_creation_recovers_by_reloading() {
+        @DisplayName("동시 참여자 생성 충돌 시 다시 조회해 복구한다")
+        void 동시_참여자_생성_충돌_시_다시_조회해_복구한다() {
             given(loadParticipantPort.load(USER_ID, CHAT_ROOM_ID))
                     .willReturn(Optional.empty())
                     .willReturn(Optional.of(userParticipant()));
@@ -97,26 +97,26 @@ class SendMessageServiceTest {
     }
 
     @Nested
-    @DisplayName("failure")
+    @DisplayName("실패")
     class Failure {
 
         @Test
-        @DisplayName("empty body throws InvalidMessageBodyException")
-        void empty_body_throws_invalid_message_body_exception() {
+        @DisplayName("빈 본문이면 InvalidMessageBodyException이 발생한다")
+        void 빈_본문이면_InvalidMessageBodyException이_발생한다() {
             assertThatThrownBy(() -> new SendMessageUseCase.Command(USER_ID, CHAT_ROOM_ID, ""))
                     .isInstanceOf(InvalidMessageBodyException.class);
         }
 
         @Test
-        @DisplayName("null body throws InvalidMessageBodyException")
-        void null_body_throws_invalid_message_body_exception() {
+        @DisplayName("null 본문이면 InvalidMessageBodyException이 발생한다")
+        void null_본문이면_InvalidMessageBodyException이_발생한다() {
             assertThatThrownBy(() -> new SendMessageUseCase.Command(USER_ID, CHAT_ROOM_ID, null))
                     .isInstanceOf(InvalidMessageBodyException.class);
         }
 
         @Test
-        @DisplayName("body longer than limit throws InvalidMessageBodyException")
-        void body_longer_than_limit_throws_invalid_message_body_exception() {
+        @DisplayName("본문 길이가 제한을 초과하면 InvalidMessageBodyException이 발생한다")
+        void 본문_길이가_제한을_초과하면_InvalidMessageBodyException이_발생한다() {
             String longBody = "a".repeat(1001);
             assertThatThrownBy(() -> new SendMessageUseCase.Command(USER_ID, CHAT_ROOM_ID, longBody))
                     .isInstanceOf(InvalidMessageBodyException.class);

--- a/backend/src/test/java/com/maeum/gohyang/cucumber/steps/CommunicationSteps.java
+++ b/backend/src/test/java/com/maeum/gohyang/cucumber/steps/CommunicationSteps.java
@@ -2,13 +2,12 @@ package com.maeum.gohyang.cucumber.steps;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
 import com.maeum.gohyang.support.adapter.ChatTestAdapter;
 import com.maeum.gohyang.support.context.ScenarioContext;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import lombok.RequiredArgsConstructor;
 
 /**
  * village_chat.feature 시나리오의 단계 정의.
@@ -18,13 +17,12 @@ import io.cucumber.java.en.When;
  * - 상태 저장은 ScenarioContext에 위임한다.
  * - 검증 표현은 비즈니스 언어로 작성한다.
  */
+@RequiredArgsConstructor
 public class CommunicationSteps {
 
-    @Autowired
-    private ChatTestAdapter chatTestAdapter;
+    private final ChatTestAdapter chatTestAdapter;
 
-    @Autowired
-    private ScenarioContext scenarioContext;
+    private final ScenarioContext scenarioContext;
 
     @When("게스트가 마을 채팅에 메시지 전송을 시도한다")
     public void 게스트가_마을_채팅에_메시지_전송을_시도한다() {
@@ -48,6 +46,6 @@ public class CommunicationSteps {
                 .as("응답에 userMessage가 포함되어야 한다")
                 .contains("userMessage")
                 .contains("body")
-                .doesNotContain("senderType");
+                .doesNotContain("\"senderType\":");
     }
 }

--- a/docs/specs/api/communication.md
+++ b/docs/specs/api/communication.md
@@ -39,6 +39,7 @@
 ## GET `/api/v1/chat/messages`
 
 인증된 회원만 최근 메시지 목록을 조회할 수 있다. 게스트는 `403`을 받는다.
+이 엔드포인트는 DB에 저장된 사용자 채팅 메시지만 반환하며, STOMP 전용 시스템 입장/퇴장 메시지는 포함하지 않는다.
 
 **Response** `200 OK`
 
@@ -58,7 +59,7 @@
 |------|------|------|
 | id | UUID | Cassandra 메시지 ID |
 | participantId | Long | 발신자 참여자 ID |
-| senderId | Long | 발신 회원 ID |
+| senderId | Long? | 발신 회원 ID. 참여자 매핑이 없으면 `null`이며 내부 `participantId`로 대체하지 않는다. |
 | body | String | 메시지 본문 |
 | createdAt | Instant | 생성 시각 |
 

--- a/docs/wiki/INDEX.md
+++ b/docs/wiki/INDEX.md
@@ -106,7 +106,7 @@ last-verified: YYYY-MM-DD       # 마지막으로 코드와 일치 확인한 날
 
 - 도메인: `identity`, `communication`, `village`, `infra`, `frontend`
 - 기술: `jwt`, `websocket`, `cassandra`, `kafka`, `phaser`, `stomp`
-- 개념: `guest`, `outbox`, `idempotency`, `pixel-art`
+- 개념: `guest`, `outbox`, `idempotency`, `pixel-art`, `ai`, `deprecated`
 
 ---
 

--- a/docs/wiki/frontend/websocket-client.md
+++ b/docs/wiki/frontend/websocket-client.md
@@ -2,7 +2,7 @@
 title: WebSocket 클라이언트
 tags: [frontend, websocket, stomp, sockjs, chat]
 related: [communication/chat-architecture.md, frontend/phaser-setup.md]
-last-verified: 2026-04-15
+last-verified: 2026-06-08
 ---
 
 # WebSocket 클라이언트

--- a/frontend/src/components/chat/ChatBubble.tsx
+++ b/frontend/src/components/chat/ChatBubble.tsx
@@ -13,7 +13,7 @@ function formatTime(iso: string): string {
 }
 
 function resolveSender(message: ChatMessage, myUserId: number | null) {
-  const isMine = message.senderId === myUserId;
+  const isMine = myUserId !== null && message.senderId === myUserId;
 
   if (isMine)
     return {


### PR DESCRIPTION
## Summary
- Fix PR #130 review feedback that should have been handled before merge.
- Stop exposing internal participantId as REST senderId fallback; senderId is now nullable when participant mapping is missing.
- Add REST MessageResponse JSON contract test, rename reviewed tests to Korean behavior names, and remove field injection from CommunicationSteps.
- Add validation DTO for librarian similar-confession query params and guard ChatBubble self-message detection when myUserId is null.
- Update communication API/wiki docs and verify docker compose config.

## Review comments intentionally not applied
- Flyway checksum / V1-V6 preservation / legacy NPC enum / V3-V4 existing DB cleanup comments were not applied because the deployment decision for this cleanup is fresh DB + rebuilt images through CD. Keeping legacy NPC migration compatibility would conflict with the explicit requirement to fully remove NPC and pgvector runtime paths.
- If an existing production DB migration path becomes required later, that should be a separate compatibility task instead of reintroducing NPC support in this cleanup.

## Verification
- .\\gradlew.bat --no-daemon clean check
- npx tsc --noEmit
- npm.cmd run test:run
- docker compose -f deploy\\docker-compose.yml config
- rg runtime NPC/pgvector search: no matches in backend/src/main, frontend/src, deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 메시지 응답의 발신자 ID가 null 값을 지원하도록 개선되었습니다.
  * 채팅 메시지 조회 시 발신자 정보 매핑 로직이 단순화되었습니다.

* **Documentation**
  * 채팅 메시지 API 명세가 업데이트되어 반환 범위와 발신자 ID 동작이 명확히 되었습니다.
  * 도서관 유사 고백 검색 엔드포인트의 파라미터 검증 규칙이 명시되었습니다.

* **Tests**
  * 메시지 응답 JSON 직렬화 검증 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->