### PR TITLE
Fix CD deploy after migration cleanup

### DIFF
--- a/backend/src/main/java/com/maeum/gohyang/global/config/FlywayConfig.java
+++ b/backend/src/main/java/com/maeum/gohyang/global/config/FlywayConfig.java
@@ -1,0 +1,34 @@
+package com.maeum.gohyang.global.config;
+
+import org.flywaydb.core.Flyway;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.flyway.autoconfigure.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayConfig {
+
+    @Bean
+    public FlywayMigrationStrategy flywayMigrationStrategy(
+            @Value("${app.flyway.repair-on-migrate:false}") boolean repairOnMigrate) {
+        return new RepairableFlywayMigrationStrategy(repairOnMigrate);
+    }
+
+    static class RepairableFlywayMigrationStrategy implements FlywayMigrationStrategy {
+
+        private final boolean repairOnMigrate;
+
+        RepairableFlywayMigrationStrategy(boolean repairOnMigrate) {
+            this.repairOnMigrate = repairOnMigrate;
+        }
+
+        @Override
+        public void migrate(Flyway flyway) {
+            if (repairOnMigrate) {
+                flyway.repair();
+            }
+            flyway.migrate();
+        }
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -107,6 +107,8 @@ village:
     max-y: 1600.0
 
 app:
+  flyway:
+    repair-on-migrate: ${APP_FLYWAY_REPAIR_ON_MIGRATE:false}
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:3001}
 

--- a/backend/src/test/java/com/maeum/gohyang/global/config/FlywayConfigTest.java
+++ b/backend/src/test/java/com/maeum/gohyang/global/config/FlywayConfigTest.java
@@ -1,0 +1,38 @@
+package com.maeum.gohyang.global.config;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class FlywayConfigTest {
+
+    @Test
+    void repair_옵션이_켜지면_repair_후_migrate를_실행한다() {
+        Flyway flyway = mock(Flyway.class);
+        FlywayConfig.RepairableFlywayMigrationStrategy strategy =
+                new FlywayConfig.RepairableFlywayMigrationStrategy(true);
+
+        strategy.migrate(flyway);
+
+        InOrder inOrder = inOrder(flyway);
+        inOrder.verify(flyway).repair();
+        inOrder.verify(flyway).migrate();
+    }
+
+    @Test
+    void repair_옵션이_꺼지면_migrate만_실행한다() {
+        Flyway flyway = mock(Flyway.class);
+        FlywayConfig.RepairableFlywayMigrationStrategy strategy =
+                new FlywayConfig.RepairableFlywayMigrationStrategy(false);
+
+        strategy.migrate(flyway);
+
+        verify(flyway, never()).repair();
+        verify(flyway).migrate();
+    }
+}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -152,6 +152,7 @@ services:
       CASSANDRA_PORT: 9042
 
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      APP_FLYWAY_REPAIR_ON_MIGRATE: ${APP_FLYWAY_REPAIR_ON_MIGRATE:-false}
 
       # ── 시크릿 (로컬은 기본값, 운영은 .env에서 덮어씀) ──
       JWT_SECRET: ${JWT_SECRET:-local-dev-only-secret-key-must-be-at-least-256-bits-long!!}

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -68,12 +68,24 @@ get_current_tag() {
   fi
 }
 
+collect_compose_diagnostics() {
+  log "▶ compose 상태 수집"
+  docker compose ps || true
+  log "▶ app 최근 로그"
+  docker compose logs --no-color --tail=200 app || true
+  log "▶ frontend 최근 로그"
+  docker compose logs --no-color --tail=100 frontend || true
+  log "▶ dependency 최근 로그"
+  docker compose logs --no-color --tail=100 postgres redis kafka cassandra cassandra-init || true
+}
+
 rollback() {
   log "▶ 이전 태그로 롤백 시도: APP_TAG=$PREV_APP_TAG FRONTEND_TAG=$PREV_FRONTEND_TAG"
   export APP_TAG="$PREV_APP_TAG"
   export FRONTEND_TAG="$PREV_FRONTEND_TAG"
   if ! docker compose up -d --wait --wait-timeout "$ROLLBACK_WAIT_TIMEOUT"; then
     log "⚠ 롤백 compose up 실패. 수동 개입 필요."
+    collect_compose_diagnostics
     return 1
   fi
   log "✅ 롤백 성공. 이전 버전으로 복구됨."
@@ -106,6 +118,9 @@ git clean -fd || die "❌ git clean 실패"
 # 이후 docker compose 명령은 deploy/ 디렉토리에서 실행해야 함.
 cd "$DEPLOY_DIR" || die "❌ DEPLOY_DIR 없음: $DEPLOY_DIR"
 
+export APP_FLYWAY_REPAIR_ON_MIGRATE="${APP_FLYWAY_REPAIR_ON_MIGRATE:-true}"
+log "  Flyway repair-on-migrate=$APP_FLYWAY_REPAIR_ON_MIGRATE"
+
 log "▶ 새 이미지 pull"
 export APP_TAG FRONTEND_TAG
 if ! docker compose pull app frontend; then
@@ -120,6 +135,7 @@ fi
 log "▶ 전체 스택 수렴 (compose idempotent) + healthcheck 대기 (최대 $((WAIT_TIMEOUT))초)"
 if ! docker compose up -d --wait --wait-timeout "$WAIT_TIMEOUT"; then
   log "❌ docker compose up 실패 또는 healthcheck 타임아웃. 롤백 수행."
+  collect_compose_diagnostics
   rollback
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Investigated latest failed CD run 27126820817. Image builds passed, but EC2 SSM deploy failed while waiting for gohyang-app healthcheck and rolled back successfully.
- The failure started after PR #130 changed already-applied Flyway migrations to no-op files while the production Postgres volume is still retained, so the most likely startup blocker is Flyway schema-history validation against changed migration checksums/descriptions.
- Add a gated Flyway migration strategy: when APP_FLYWAY_REPAIR_ON_MIGRATE=true, run flyway.repair() before migrate(). The app default remains false.
- CD deploy.sh now exports APP_FLYWAY_REPAIR_ON_MIGRATE=true by default for deploy runs and collects compose/app/frontend/dependency logs before rollback on failures.

## Verification
- backend: .\\gradlew.bat --no-daemon check
- deploy: docker compose -f deploy\\docker-compose.yml config
- git diff --check

## Notes
- bash -n could not run locally because Windows bash resolves to WSL and no default distro is installed.
- This keeps NPC/pgvector runtime removal intact; it only repairs Flyway schema history for the retained deployment DB.