### PR TITLE
Rebuild app images when deploy config changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
   build-backend:
     name: Backend 이미지 빌드
     needs: detect-changes
-    if: needs.detect-changes.outputs.backend == 'true' || inputs.force_rebuild
+    if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.deploy == 'true' || inputs.force_rebuild
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -92,7 +92,7 @@ jobs:
   build-frontend:
     name: Frontend 이미지 빌드
     needs: detect-changes
-    if: needs.detect-changes.outputs.frontend == 'true' || inputs.force_rebuild
+    if: needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.deploy == 'true' || inputs.force_rebuild
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Fix the CD condition that let deploy-only changes reuse stale app/frontend image tags after a rollback.
- When deploy/** or .github/workflows/deploy.yml changes, build both backend and frontend images so the deploy script and image tags converge on the same commit.

## Root cause from production
- CD run 27128577766 succeeded after backend-only rebuild, but kept FRONTEND_TAG=d15d01... from rollback state.
- That left the old frontend calling removed chat endpoints such as /api/v1/chat/mentionables against the new backend.
- A force rebuild deploy has already synced production to APP_TAG=FRONTEND_TAG=8c57ec8.

## Verification
- git diff --check
- Production force rebuild CD run 27129913256 succeeded with both tags set to 8c57ec8
- Unauthenticated external REST probes now return 403 rather than 500 for /api/v1/chat/messages and /api/v1/chat/mentionables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 워크플로우의 빌드 실행 조건을 개선했습니다. 이제 경로 변경 감지, 강제 재빌드 옵션, 또는 배포 트리거 중 하나의 조건에서 이미지 빌드가 수행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->