### PR TITLE
Gate CD on passing CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,122 +1,134 @@
 name: CD
 
-# 같은 EC2에 두 배포가 동시에 실행되면 서로의 git reset·docker up·롤백을 덮어쓴다.
-# 동일 그룹 내에서 직렬화하되, 진행 중 배포는 취소하지 않고 큐잉한다
-# (cancel-in-progress: false) — 배포 도중 중단되면 중간 상태로 서비스가 멈출 수 있음.
 concurrency:
   group: prod-deploy
   cancel-in-progress: false
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - '.claude/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - 'llm-test/**'
-      # 모니터링 스택은 별도 EC2(gohyang-monitor)에서 동작 → 운영 CD와 무관.
-      - 'monitoring/**'
+    types: [completed]
   workflow_dispatch:
     inputs:
       force_rebuild:
-        description: '변경 감지 무시하고 강제 재빌드'
+        description: "Ignore change detection and rebuild both images"
         required: false
         type: boolean
         default: false
 
 permissions:
-  id-token: write    # OIDC 토큰 발급
+  id-token: write
   contents: read
-  packages: write    # GHCR push
+  packages: write
 
 env:
   AWS_REGION: ap-northeast-2
   IMAGE_APP: ghcr.io/zkzkzhzj/gohyang-app
   IMAGE_FRONTEND: ghcr.io/zkzkzhzj/gohyang-frontend
+  DEPLOY_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
 jobs:
   detect-changes:
-    name: 변경 영역 감지
+    name: Detect changed areas
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
-      frontend: ${{ steps.filter.outputs.frontend }}
-      deploy: ${{ steps.filter.outputs.deploy }}
+      backend: ${{ steps.detect.outputs.backend }}
+      frontend: ${{ steps.detect.outputs.frontend }}
+      deploy: ${{ steps.detect.outputs.deploy }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          # 이미지 빌드 필터는 각 컴포넌트 소스만 포함한다.
-          # compose/스크립트/워크플로우 변경은 "재배포는 필요하지만 재빌드는 불필요" →
-          # 별도 deploy 필터로 분리하여 불필요한 이미지 재빌드를 방지.
-          filters: |
-            backend:
-              - 'backend/**'
-            frontend:
-              - 'frontend/**'
-            deploy:
-              - 'deploy/**'
-              - '.github/workflows/deploy.yml'
+          ref: ${{ env.DEPLOY_SHA }}
+          fetch-depth: 2
+
+      - name: Detect changed areas
+        id: detect
+        run: |
+          set -euo pipefail
+
+          if git rev-parse HEAD^ >/dev/null 2>&1; then
+            git diff --name-only HEAD^ HEAD > changed-files.txt
+          else
+            git show --pretty="" --name-only HEAD > changed-files.txt
+          fi
+
+          backend=false
+          frontend=false
+          deploy=false
+
+          if grep -Eq '^backend/' changed-files.txt; then
+            backend=true
+          fi
+          if grep -Eq '^frontend/' changed-files.txt; then
+            frontend=true
+          fi
+          if grep -Eq '^(deploy/|\.github/workflows/deploy\.yml$)' changed-files.txt; then
+            deploy=true
+          fi
+
+          echo "backend=$backend" >> "$GITHUB_OUTPUT"
+          echo "frontend=$frontend" >> "$GITHUB_OUTPUT"
+          echo "deploy=$deploy" >> "$GITHUB_OUTPUT"
 
   build-backend:
-    name: Backend 이미지 빌드
+    name: Build backend image
     needs: detect-changes
-    if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.deploy == 'true' || inputs.force_rebuild
+    if: needs.detect-changes.outputs.backend == 'true' || needs.detect-changes.outputs.deploy == 'true' || (github.event_name == 'workflow_dispatch' && inputs.force_rebuild)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
 
       - uses: docker/setup-buildx-action@v4
 
-      - name: GHCR 로그인
+      - name: Login to GHCR
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Backend 이미지 빌드·푸시
+      - name: Build and push backend image
         uses: docker/build-push-action@v7
         with:
           context: ./backend
           push: true
           tags: |
-            ${{ env.IMAGE_APP }}:${{ github.sha }}
+            ${{ env.IMAGE_APP }}:${{ env.DEPLOY_SHA }}
             ${{ env.IMAGE_APP }}:latest
           cache-from: type=gha,scope=backend
           cache-to: type=gha,mode=max,scope=backend
 
   build-frontend:
-    name: Frontend 이미지 빌드
+    name: Build frontend image
     needs: detect-changes
-    if: needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.deploy == 'true' || inputs.force_rebuild
+    if: needs.detect-changes.outputs.frontend == 'true' || needs.detect-changes.outputs.deploy == 'true' || (github.event_name == 'workflow_dispatch' && inputs.force_rebuild)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
 
       - uses: docker/setup-buildx-action@v4
 
-      - name: GHCR 로그인
+      - name: Login to GHCR
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Frontend 이미지 빌드·푸시
+      - name: Build and push frontend image
         uses: docker/build-push-action@v7
         with:
           context: ./frontend
           push: true
           tags: |
-            ${{ env.IMAGE_FRONTEND }}:${{ github.sha }}
+            ${{ env.IMAGE_FRONTEND }}:${{ env.DEPLOY_SHA }}
             ${{ env.IMAGE_FRONTEND }}:latest
-          # NEXT_PUBLIC_* 는 빌드 타임에 Next.js 번들에 인라인된다.
-          # staging/prod 분리 시 환경별 vars로 오버라이드하려면 이 build-args를
-          # `${{ vars.NEXT_PUBLIC_API_URL }}` 형태로 바꾸면 된다. 지금은 단일 환경(prod)이라 하드코딩.
           build-args: |
             NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL || 'https://ghworld.co' }}
             NEXT_PUBLIC_WS_URL=${{ vars.NEXT_PUBLIC_WS_URL || 'https://ghworld.co/ws' }}
@@ -125,55 +137,51 @@ jobs:
           cache-to: type=gha,mode=max,scope=frontend
 
   deploy:
-    name: EC2 배포 (SSM)
+    name: Deploy to EC2 with SSM
     needs: [detect-changes, build-backend, build-frontend]
     if: |
       always() &&
+      needs.detect-changes.result == 'success' &&
       (needs.build-backend.result == 'success' || needs.build-backend.result == 'skipped') &&
       (needs.build-frontend.result == 'success' || needs.build-frontend.result == 'skipped') &&
       (needs.detect-changes.outputs.backend == 'true' ||
        needs.detect-changes.outputs.frontend == 'true' ||
        needs.detect-changes.outputs.deploy == 'true' ||
-       inputs.force_rebuild)
+       (github.event_name == 'workflow_dispatch' && inputs.force_rebuild))
     runs-on: ubuntu-latest
     steps:
-      - name: AWS 자격 증명 (OIDC)
+      - name: Configure AWS credentials with OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: 배포 태그 결정
+      - name: Resolve deploy tags
         id: tags
         run: |
-          # 빌드가 성공한 컴포넌트만 현재 sha 태그로 배포.
-          # 스킵된(변경 없는) 컴포넌트는 빈 문자열을 넘겨 deploy.sh가 현재 실행 중인 태그를 유지하게 함.
-          # (latest fallback은 이전 실패 배포가 남긴 bad 이미지를 가리킬 수 있어 비결정적)
           if [ "${{ needs.build-backend.result }}" = "success" ]; then
-            echo "app_tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "app_tag=${{ env.DEPLOY_SHA }}" >> "$GITHUB_OUTPUT"
           else
             echo "app_tag=" >> "$GITHUB_OUTPUT"
           fi
           if [ "${{ needs.build-frontend.result }}" = "success" ]; then
-            echo "frontend_tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "frontend_tag=${{ env.DEPLOY_SHA }}" >> "$GITHUB_OUTPUT"
           else
             echo "frontend_tag=" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: SSM으로 배포 명령 실행
+      - name: Run deploy command through SSM
         id: ssm
         env:
-          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_SHA: ${{ env.DEPLOY_SHA }}
           APP_TAG: ${{ steps.tags.outputs.app_tag }}
           FRONTEND_TAG: ${{ steps.tags.outputs.frontend_tag }}
           INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
         run: |
           set -euo pipefail
 
-          echo "▶ Deploying commit=$COMMIT_SHA APP_TAG=${APP_TAG:-<keep>} FRONTEND_TAG=${FRONTEND_TAG:-<keep>} to $INSTANCE_ID"
+          echo "Deploying commit=$COMMIT_SHA APP_TAG=${APP_TAG:-<keep>} FRONTEND_TAG=${FRONTEND_TAG:-<keep>} to $INSTANCE_ID"
 
-          # deploy.sh 인자를 양끝 따옴표로 감싸 안전 확보.
-          # COMMIT_SHA는 git SHA(hex)라 안전하지만 방어적 quoting.
           PARAMS=$(jq -n \
             --arg sha "$COMMIT_SHA" \
             --arg app "$APP_TAG" \
@@ -191,7 +199,7 @@ jobs:
           echo "Command ID: $CMD_ID"
           echo "command_id=$CMD_ID" >> "$GITHUB_OUTPUT"
 
-      - name: 배포 완료 대기 + 로그 수집
+      - name: Wait for deploy and collect logs
         env:
           INSTANCE_ID: ${{ secrets.EC2_INSTANCE_ID }}
           CMD_ID: ${{ steps.ssm.outputs.command_id }}
@@ -209,7 +217,7 @@ jobs:
 
             case "$STATUS" in
               Success)
-                echo "── stdout ──"
+                echo "----- stdout -----"
                 aws ssm get-command-invocation \
                   --command-id "$CMD_ID" \
                   --instance-id "$INSTANCE_ID" \
@@ -218,13 +226,13 @@ jobs:
                 exit 0
                 ;;
               Failed|Cancelled|TimedOut)
-                echo "── stdout ──"
+                echo "----- stdout -----"
                 aws ssm get-command-invocation \
                   --command-id "$CMD_ID" \
                   --instance-id "$INSTANCE_ID" \
                   --query 'StandardOutputContent' \
                   --output text || true
-                echo "── stderr ──"
+                echo "----- stderr -----"
                 aws ssm get-command-invocation \
                   --command-id "$CMD_ID" \
                   --instance-id "$INSTANCE_ID" \
@@ -237,5 +245,5 @@ jobs:
             sleep 10
           done
 
-          echo "❌ 배포 타임아웃 (10분)"
+          echo "Deploy timed out after 10 minutes"
           exit 1

--- a/backend/src/test/java/com/maeum/gohyang/communication/adapter/in/websocket/v2/ChatWebSocketV2IntegrationTest.java
+++ b/backend/src/test/java/com/maeum/gohyang/communication/adapter/in/websocket/v2/ChatWebSocketV2IntegrationTest.java
@@ -71,6 +71,9 @@ class ChatWebSocketV2IntegrationTest extends BaseTestContainers {
     @Autowired
     RoomSubscriptionRegistry subscriptionRegistry;
 
+    @Autowired
+    WebSocketSessionRegistry sessionRegistry;
+
     private final List<WebSocketSession> openSessions = new ArrayList<>();
 
     @AfterEach
@@ -81,6 +84,13 @@ class ChatWebSocketV2IntegrationTest extends BaseTestContainers {
             }
         }
         openSessions.clear();
+        Awaitility.await()
+                .atMost(EVENT_AT_MOST)
+                .pollInterval(PROPAGATION_POLL_INTERVAL)
+                .untilAsserted(() -> {
+                    assertThat(subscriptionRegistry.roomCount()).isZero();
+                    assertThat(sessionRegistry.size()).isZero();
+                });
     }
 
     @Test
@@ -251,6 +261,15 @@ class ChatWebSocketV2IntegrationTest extends BaseTestContainers {
         sessionA.sendMessage(new TextMessage("{\"type\":\"SUBSCRIBE\",\"roomId\":" + roomId + "}"));
         sessionB.sendMessage(new TextMessage("{\"type\":\"SUBSCRIBE\",\"roomId\":" + roomId + "}"));
         awaitSessionCount(roomId, 2);
+        drain(queueB);
+        sessionA.sendMessage(new TextMessage(
+                "{\"type\":\"POSITION\",\"roomId\":" + roomId + ",\"x\":10.0,\"y\":20.0}"));
+        awaitMessageContaining(queueB,
+                "\"POSITION_UPDATE\"",
+                "\"displayId\":\"user-1001\"",
+                "\"userType\":\"MEMBER\"",
+                "\"x\":10.0",
+                "\"y\":20.0");
         drain(queueB);
 
         // When


### PR DESCRIPTION
## Summary
- run CD automatically only after the CI workflow completes successfully on main
- keep manual CD dispatch with force rebuild support
- stabilize the WebSocket leave-position integration test by waiting for fan-out readiness and registry cleanup

## Verification
- ./gradlew.bat --no-daemon check
- git diff --check