### PR TITLE
Fix chat system messages and history load

### DIFF
--- a/frontend/src/lib/websocket/stompRealtimeSubscriptions.test.ts
+++ b/frontend/src/lib/websocket/stompRealtimeSubscriptions.test.ts
@@ -58,6 +58,17 @@ function userMessage(): MessageResponse {
   };
 }
 
+function systemMessage(): MessageResponse {
+  return {
+    id: 'system-1',
+    participantId: 0,
+    senderId: null,
+    senderType: 'SYSTEM',
+    body: '이웃이 입장하셨습니다.',
+    createdAt: '2026-04-08T12:00:01.000Z',
+  };
+}
+
 describe('subscribeToStompRealtimeChannels', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -93,6 +104,27 @@ describe('subscribeToStompRealtimeChannels', () => {
     const onMessage = mockSubscribeToChatRoom.mock.calls[0][1] as (msg: MessageResponse) => void;
 
     onMessage(userMessage());
+
+    expect(addMessage).toHaveBeenCalledWith(expectedMessage);
+    expect(mockEmitChatMessage).toHaveBeenCalledWith(expectedMessage);
+  });
+
+  it('preserves system chat messages so they render as system logs', () => {
+    const addMessage = vi.fn();
+    const expectedMessage = {
+      id: 'system-1',
+      participantId: 0,
+      senderId: null,
+      senderType: 'SYSTEM',
+      body: '이웃이 입장하셨습니다.',
+      createdAt: '2026-04-08T12:00:01.000Z',
+    };
+    subscribeToStompRealtimeChannels({
+      addMessage,
+    });
+    const onMessage = mockSubscribeToChatRoom.mock.calls[0][1] as (msg: MessageResponse) => void;
+
+    onMessage(systemMessage());
 
     expect(addMessage).toHaveBeenCalledWith(expectedMessage);
     expect(mockEmitChatMessage).toHaveBeenCalledWith(expectedMessage);

--- a/frontend/src/lib/websocket/stompRealtimeSubscriptions.ts
+++ b/frontend/src/lib/websocket/stompRealtimeSubscriptions.ts
@@ -21,6 +21,7 @@ function toMessage(msg: MessageResponse): ChatMessage {
     id: msg.id,
     participantId: msg.participantId,
     senderId: msg.senderId,
+    senderType: msg.senderType,
     body: msg.body,
     createdAt: msg.createdAt,
   };

--- a/frontend/src/lib/websocket/useStomp.test.tsx
+++ b/frontend/src/lib/websocket/useStomp.test.tsx
@@ -8,14 +8,18 @@ const {
   mockConnectWithAuth,
   mockDisconnectStomp,
   mockEnsureValidRealtimeToken,
+  mockGet,
   mockParseTokenRole,
+  mockPrependMessages,
   mockSetLoginRequired,
   mockSubscribeToStompRealtimeChannels,
 } = vi.hoisted(() => ({
   mockConnectWithAuth: vi.fn(),
   mockDisconnectStomp: vi.fn(),
   mockEnsureValidRealtimeToken: vi.fn(),
+  mockGet: vi.fn(),
   mockParseTokenRole: vi.fn(),
+  mockPrependMessages: vi.fn(),
   mockSetLoginRequired: vi.fn(),
   mockSubscribeToStompRealtimeChannels: vi.fn(),
 }));
@@ -32,7 +36,7 @@ vi.mock('./realtimeAuth', () => ({
 }));
 
 vi.mock('@/lib/api/client', () => ({
-  default: { get: vi.fn().mockResolvedValue({ data: [] }) },
+  default: { get: mockGet },
 }));
 
 vi.mock('./tokenBridge', () => ({
@@ -52,7 +56,7 @@ vi.mock('@/store/useChatStore', () => ({
     (selector: (s: unknown) => unknown) =>
       selector({
         addMessage: vi.fn(),
-        prependMessages: vi.fn(),
+        prependMessages: mockPrependMessages,
         setConnectionStatus: vi.fn(),
         setLoginRequired: mockSetLoginRequired,
       }),
@@ -88,7 +92,10 @@ describe('useStomp — 멤버 토큰 만료 시 STOMP 자동 reconnect 차단', 
     mockConnectWithAuth.mockReset();
     mockDisconnectStomp.mockReset();
     mockEnsureValidRealtimeToken.mockReset();
+    mockGet.mockReset();
+    mockGet.mockResolvedValue({ data: [] });
     mockParseTokenRole.mockReset();
+    mockPrependMessages.mockReset();
     mockSetLoginRequired.mockReset();
     mockSubscribeToStompRealtimeChannels.mockReset();
     mockSubscribeToStompRealtimeChannels.mockReturnValue(vi.fn());
@@ -154,5 +161,40 @@ describe('useStomp — 멤버 토큰 만료 시 STOMP 자동 reconnect 차단', 
     onError(tokenInvalidError);
 
     expect(mockSetLoginRequired).not.toHaveBeenCalled();
+  });
+
+  it('member connection loads recent chat history and prepends it in chronological order', async () => {
+    const member = tokenWithRole('MEMBER');
+    const latest = {
+      id: 'message-2',
+      participantId: 11,
+      senderId: 43,
+      body: 'latest',
+      createdAt: '2026-04-08T12:01:00.000Z',
+    };
+    const older = {
+      id: 'message-1',
+      participantId: 10,
+      senderId: 42,
+      body: 'older',
+      createdAt: '2026-04-08T12:00:00.000Z',
+    };
+    localStorage.setItem('accessToken', member);
+    mockEnsureValidRealtimeToken.mockResolvedValue(member);
+    mockParseTokenRole.mockReturnValue('MEMBER');
+    mockGet.mockResolvedValue({ data: [latest, older] });
+
+    render(<TestHarness />);
+
+    await waitFor(() => {
+      expect(mockConnectWithAuth).toHaveBeenCalled();
+    });
+    const onConnected = mockConnectWithAuth.mock.calls[0][1] as () => void;
+    onConnected();
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith('/api/v1/chat/messages');
+      expect(mockPrependMessages).toHaveBeenCalledWith([older, latest]);
+    });
   });
 });

--- a/frontend/src/lib/websocket/useStomp.ts
+++ b/frontend/src/lib/websocket/useStomp.ts
@@ -25,6 +25,7 @@ function toMessage(msg: MessageResponse): ChatMessage {
     id: msg.id,
     participantId: msg.participantId,
     senderId: msg.senderId,
+    senderType: msg.senderType,
     body: msg.body,
     createdAt: msg.createdAt,
   };

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -11,6 +11,7 @@ export interface MessageResponse {
   id: string;
   participantId: number;
   senderId: number | null;
+  senderType?: 'SYSTEM';
   body: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- preserve senderType from chat responses so system presence events render as system logs
- preserve senderType in both initial history load and realtime STOMP messages
- add regression tests for system message mapping and member history loading

## Verification
- npx tsc --noEmit
- npm run test -- --run src/lib/websocket/stompRealtimeSubscriptions.test.ts src/lib/websocket/useStomp.test.tsx
- npm run lint
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 실시간 채팅 구독에서 시스템 메시지 지원 추가
  * 메시지 객체에 발신자 유형 정보 포함

* **개선 사항**
  * 멤버 연결 시 최근 채팅 메시지를 시간순으로 자동 로드하고 정렬하는 기능 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->