### PR TITLE
Align README and WebSocket docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **<https://ghworld.co>**
 
 누군가의 온기가 필요할 때, 고향에 온 듯한 편안함을 느끼며 대화할 수 있는 **마을**을 제공한다.
-인터랙티브 2D 공간에서 캐릭터가 마을을 돌아다니고, 자기 공간을 꾸미며, 이웃(유저 또는 AI 주민)과 자연스럽게 소통하는 서비스다.
+인터랙티브 3D 공간에서 캐릭터가 마을과 도서관을 오가고, 이웃 유저와 자연스럽게 소통하는 서비스다.
 
 ---
 
@@ -14,8 +14,8 @@
 | 기능 | 설명 | 상태 |
 |------|------|------|
 | 회원가입/로그인 | 이메일 기반 인증 + 게스트 토큰 | ✅ 구현 완료 |
-| 마을 공간 | 인터랙티브 2D 마을 (Phaser.js). 카메라 팔로우, 대각선 이동 | ✅ 구현 완료 |
-| 마을 공개 채팅 | WebSocket(STOMP) 실시간 채팅. 유저/이웃 메시지 구분 | ✅ 구현 완료 |
+| 마을/도서관 공간 | Three.js 기반 3D 마을과 도서관. 캐릭터 이동, 카메라 팔로우, 씬 전환 | ✅ 구현 완료 |
+| 마을 공개 채팅 | WebSocket(STOMP) 실시간 채팅. 유저 메시지와 시스템 메시지 구분 | ✅ 구현 완료 |
 | @멘션 NPC | 일반 채팅에서 제거. 사서 RAG는 별도 트랙에서 설계 | 제거됨 |
 | 실시간 위치 공유 | STOMP 기반 캐릭터 위치 broadcast + 입퇴장 감지 | ✅ 구현 완료 |
 | 타이핑 인디케이터 | 상대방 입력 중 표시 | ✅ 구현 완료 |
@@ -48,15 +48,16 @@
 | Redis 7.2 | 세션/캐시 |
 | Cassandra 4.1 | 채팅 메시지 저장 (write-heavy) |
 | Kafka 3.7 (KRaft) | 도메인 간 비동기 이벤트 + Transactional Outbox |
-| Ollama | 로컬 LLM 서빙 (exaone3.5:7.8b) |
+| LLM | 일반 채팅 자동 응답은 제거됨. 사서 RAG는 후속 트랙 |
 
 ### Frontend
 
 | 항목 | 버전/설명 |
 |------|-----------|
-| Next.js | 16.2.2 (App Router) |
-| React | 19.2.4 |
-| Phaser.js | 3.90.0 (2D 마을 렌더링) |
+| Next.js | 16.2.6 (App Router) |
+| React | 19.2.6 |
+| Three.js | 0.184.x (3D 마을/도서관 렌더링) |
+| Howler.js | ^2.2.4 (환경음 재생) |
 | Tailwind CSS | 4.x (`@theme` 디자인 토큰) |
 | Zustand | 채팅/게임 상태 관리 |
 
@@ -86,7 +87,7 @@ Hexagonal Architecture (Ports & Adapters)
 Controller      →     UseCase               →  JPA Repository
 WebSocket       →     Domain Service        →  Cassandra Repository
 Kafka Consumer  →     Domain Entity         →  Kafka Producer (Outbox)
-                      Port (interface)      →  Ollama LLM API
+                      Port (interface)      →  External service adapter
 ```
 
 ### 도메인 구성
@@ -157,9 +158,9 @@ ChatAppProject/
 ├── frontend/                   # Next.js 클라이언트
 │   ├── src/app/                # App Router 페이지
 │   ├── src/components/chat/    # 채팅 UI 컴포넌트
-│   ├── src/game/               # Phaser 게임 씬
+│   ├── src/three/              # Three.js 씬, 캐릭터, 오디오, 채팅 연동
 │   ├── src/hooks/              # 커스텀 훅
-│   └── src/lib/websocket/      # STOMP 클라이언트
+│   └── src/lib/websocket/      # STOMP/raw WebSocket 클라이언트 facade
 ├── docs/                       # 프로젝트 문서
 │   ├── architecture/           # 아키텍처, ERD, ADR
 │   ├── specs/                  # API/WebSocket/이벤트 명세

--- a/docs/specs/websocket.md
+++ b/docs/specs/websocket.md
@@ -67,8 +67,8 @@ stompClient.connect(
 
 ### `/topic/chat/village` — 메시지 수신
 
-유저 메시지와 NPC 응답이 **개별 `MessageResponse`**로 구독자 전체에게 broadcast된다.
-유저 메시지는 전송 즉시, NPC 응답은 비동기 생성 후 별도로 broadcast된다.
+유저 메시지와 SYSTEM 입장/퇴장 알림이 **개별 `MessageResponse`**로 구독자 전체에게 broadcast된다.
+일반 채팅의 NPC 자동 응답은 제거되었으며, 사서 RAG는 별도 후속 트랙에서 다룬다.
 
 **구독 예시 (JavaScript)**
 
@@ -94,25 +94,12 @@ stompClient.subscribe('/topic/chat/village', (message) => {
 }
 ```
 
-NPC 응답 예시 (비동기, 별도 broadcast):
-
-```json
-{
-  "id": "660f9511-f30c-52e5-b827-557766551111",
-  "participantId": 2,
-  "senderId": null,
-  "senderType": "NPC",
-  "body": "어서오세요, 마을에 오신 것을 환영합니다!",
-  "createdAt": "2026-04-08T12:00:00.001Z"
-}
-```
-
 | 필드 | 타입 | 비고 |
 |------|------|------|
 | id | UUID | 메시지 ID (Cassandra) |
 | participantId | Long | 참여자 ID |
-| senderId | Long (nullable) | 유저 메시지: 유저 ID, NPC 메시지: `null` |
-| senderType | String | `"USER"`, `"NPC"`, 또는 `"SYSTEM"` |
+| senderId | Long (nullable) | 유저 메시지: 유저 ID, SYSTEM 메시지: `null` |
+| senderType | String | `"USER"` 또는 `"SYSTEM"` |
 | body | String | 메시지 본문 |
 | createdAt | Instant (ISO 8601 UTC) | 메시지 생성 시각 |
 
@@ -149,13 +136,11 @@ REST POST /api/v1/chat/messages
   → SendMessageUseCase 실행
   → 유저 MessageResponse를 /topic/chat/village로 broadcast (단일 객체)
   → REST 응답으로 SendMessageResponse(userMessage만) 반환
-  → NPC 응답은 @Async 비동기 → 별도 MessageResponse broadcast
 
 STOMP /app/chat/village
   → 동일한 SendMessageUseCase 실행
   → 유저 MessageResponse를 /topic/chat/village로 broadcast (단일 객체)
   → STOMP 응답 없음 (구독 채널로만 수신)
-  → NPC 응답은 @Async 비동기 → 별도 MessageResponse broadcast
 ```
 
 Happy Path Cucumber 테스트는 REST로 수행한다.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,43 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# ghworld frontend
 
-## Getting Started
+Next.js App Router 기반 클라이언트다. Three.js로 마을/도서관 씬을 렌더링하고, STOMP를 운영 기본 실시간 경로로 사용한다. raw WebSocket `/ws/v2`는 전환 후보로 남겨둔다.
 
-First, run the development server:
+## Stack
+
+| 항목 | 버전/역할 |
+|------|-----------|
+| Next.js | 16.2.6 |
+| React | 19.2.6 |
+| Three.js | 3D 마을/도서관 렌더링 |
+| Howler.js | 환경음 |
+| Zustand | 클라이언트 상태 |
+| Vitest | 단위 테스트 |
+
+## Local
 
 ```bash
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+기본 개발 주소는 `http://localhost:3000`이다.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Scripts
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+npm run lint
+npm run format:check
+npm run build
+npm run test:run
+```
 
-## Learn More
+## Structure
 
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```text
+src/app/              App Router 진입점
+src/components/chat/  채팅 UI
+src/components/library/ 도서관/고백 UI
+src/lib/websocket/    STOMP/raw WebSocket 클라이언트
+src/three/            Three.js 씬, 캐릭터, 오디오, 말풍선
+src/types/            API/UI 타입
+```


### PR DESCRIPTION
## Summary
- Update README to describe the current Three.js frontend and package versions
- Replace the default frontend README with project-specific frontend docs
- Remove stale general-chat NPC response details from the STOMP WebSocket spec

## Verification
- git diff --check
- npm.cmd run lint:md
- npm.cmd exec markdownlint-cli2 frontend/README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 서비스 설명서를 3D 공간 기반 마을·도서관 탐험으로 업데이트
  * 웹소켓 채팅 명세서를 간결하게 정리
  * 프론트엔드 프로젝트 가이드 문서 추가 (스택, 로컬 실행, 주요 스크립트 포함)

* **New Features**
  * 3D 공간 내 카메라 팔로우 및 씬 전환 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->