### PR TITLE
Fix daily visit type aggregation

### DIFF
--- a/backend/src/main/java/com/maeum/gohyang/village/adapter/out/persistence/DailyVisitJpaRepository.java
+++ b/backend/src/main/java/com/maeum/gohyang/village/adapter/out/persistence/DailyVisitJpaRepository.java
@@ -14,7 +14,7 @@ public interface DailyVisitJpaRepository extends JpaRepository<DailyVisitJpaEnti
     @Modifying
     @Query(value = "INSERT INTO daily_visit "
             + "(visit_date, visitor_key, visitor_type, created_at) "
-            + "VALUES (:visitDate, :visitorKey, :visitorType, NOW()) "
+            + "VALUES (:visitDate, :visitorKey, :#{#visitorType.name()}, NOW()) "
             + "ON CONFLICT (visit_date, visitor_key) DO NOTHING",
             nativeQuery = true)
     int insertIfAbsent(

--- a/backend/src/test/java/com/maeum/gohyang/village/adapter/out/persistence/DailyVisitJpaRepositoryTest.java
+++ b/backend/src/test/java/com/maeum/gohyang/village/adapter/out/persistence/DailyVisitJpaRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.maeum.gohyang.village.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.maeum.gohyang.support.BaseTestContainers;
+import com.maeum.gohyang.village.domain.DailyVisitType;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Transactional
+class DailyVisitJpaRepositoryTest extends BaseTestContainers {
+
+    @Autowired DailyVisitJpaRepository repository;
+
+    @Test
+    @DisplayName("native insert 방문 타입은 타입별 집계와 같은 문자열 값으로 저장된다")
+    void native_insert_방문_타입은_타입별_집계와_같은_문자열_값으로_저장된다() {
+        LocalDate visitDate = LocalDate.of(2026, 6, 20);
+
+        int guestInserted = repository.insertIfAbsent(visitDate, "guest-1", DailyVisitType.GUEST);
+        int memberInserted = repository.insertIfAbsent(visitDate, "member-1", DailyVisitType.MEMBER);
+
+        assertThat(guestInserted).isOne();
+        assertThat(memberInserted).isOne();
+        assertThat(repository.countByVisitDate(visitDate)).isEqualTo(2);
+        assertThat(repository.countByVisitDateAndVisitorType(visitDate, DailyVisitType.GUEST)).isOne();
+        assertThat(repository.countByVisitDateAndVisitorType(visitDate, DailyVisitType.MEMBER)).isOne();
+    }
+}


### PR DESCRIPTION
## Summary
- Fix daily visit native insert to persist enum names for visitor_type.
- Add PostgreSQL-backed regression test for total, guest, and member counts.

## Tests
- DailyVisitJpaRepositoryTest passed locally.
- Backend check passed locally.

## Operational note
Existing production rows inserted with a non-string visitor_type value may need one-time DB correction for already-recorded visits.