### PR TITLE
Fix Flyway checksum and polish library UX

### DIFF
--- a/backend/src/main/resources/db/migration/V11__drop_personalization_and_economy.sql
+++ b/backend/src/main/resources/db/migration/V11__drop_personalization_and_economy.sql
@@ -1,7 +1,5 @@
 -- Remove persisted personal space, character customization, and economy tables.
 -- Runtime avatars and WebSocket presence remain non-persisted village behavior.
--- This migration is intentionally irreversible. Confirm a database backup and
--- production table data review before applying it outside disposable environments.
 
 DROP TABLE IF EXISTS character_equipment;
 DROP TABLE IF EXISTS space_placement;

--- a/docs/superpowers/specs/2026-06-24-fairy-forest-hideout-design.md
+++ b/docs/superpowers/specs/2026-06-24-fairy-forest-hideout-design.md
@@ -1,0 +1,38 @@
+# Fairy Forest Hideout Visual Design
+
+## Goal
+
+Make the village feel closer to a fairy-tale secret forest hideout while staying within free-to-use assets and reversible procedural Three.js changes.
+
+## Non-Goals
+
+- Do not add paid assets.
+- Do not add user-owned decoration, inventory, placement, or persistence.
+- Do not replace the current 3D scene architecture.
+- Do not introduce large binary assets in this pass.
+
+## Visual Direction
+
+The target mood is "storybook forest hideout": warm, cute, dense, and discoverable. The main path should feel less like a plain straight lane and more like a hidden trail framed by flowers, mushrooms, leaves, and lantern light. The campfire area should read as a secret gathering circle, and the library entrance should feel like a small place found inside the woods.
+
+## Asset Strategy
+
+- Use procedural Three.js geometry first for mushrooms, lanterns, leaf arches, glow stones, flower clusters, and garlands.
+- Keep existing free/CC0-compatible assets available in the repo.
+- Treat Kenney and Poly Haven as safe future candidates only after each concrete asset is selected and recorded in `frontend/public/assets/village/LICENSE.md`.
+- Avoid CC BY or unclear assets in this pass so no new public credits surface is required.
+
+## Implementation Shape
+
+- Extend `frontend/src/three/scenes/villageDecor.ts`.
+- Keep all new objects deterministic and static except existing low-frequency update loops.
+- Add `userData.villageDecorRole` markers for new visual groups so tests can confirm the scene composition.
+- Keep ground-level meshes outside the protected central walking path.
+
+## Acceptance Criteria
+
+- The scene includes a fairy mushroom ring around the campfire.
+- The central trail has flower/glow details and hanging lantern garlands.
+- The library approach has a leafy secret arch and richer entrance dressing.
+- Existing path clearance remains protected.
+- Relevant Three.js scene tests pass.

--- a/docs/wiki/frontend/asset-guide.md
+++ b/docs/wiki/frontend/asset-guide.md
@@ -2,7 +2,7 @@
 title: 에셋 가이드
 tags: [frontend, assets, threejs, village, library, remote-player, audio]
 related: [village/space-system.md, village/character-system.md]
-last-verified: 2026-06-23
+last-verified: 2026-06-24
 ---
 
 # 에셋 가이드
@@ -38,6 +38,18 @@ last-verified: 2026-06-23
 | Freesound | CC0 또는 상용 허용 CC BY만 | 환경음 |
 
 CC BY 자산은 `LICENSE.md` 또는 credits 문서에 출처를 남긴다. 라이선스가 불명확한 자산은 사용하지 않는다.
+
+## 유료 에셋 선택지
+
+> 아래 항목은 도입 예정이 아니라, 무료/절차적 자산의 한계를 넘고 싶을 때 검토할 수 있는 선택지다.
+
+| 후보 | 링크 | 기대 효과 | 검토 조건 |
+|------|------|-----------|-----------|
+| Synty POLYGON Town Pack | <https://syntystore.com/products/polygon-town-pack> | 마을 건물, 상점, 길가 props, 저폴리 도시/마을 톤 통일 | 구매 전 라이선스 확인, 필요한 FBX/GLB만 선별 변환 |
+| Synty POLYGON Nature Pack | <https://syntystore.com/products/polygon-nature-pack> | 숲, 바위, 나무, 자연물 밀도 개선 | 현재 절차적 데코와 톤 충돌 여부 확인 |
+| Synty POLYGON Fantasy Kingdom | <https://syntystore.com/products/polygon-fantasy-kingdom> | 동화풍 장소성, 판타지 구조물, 비밀 공간 연출 | 서비스 톤이 과도하게 RPG처럼 보이지 않는지 확인 |
+
+유료 에셋을 쓰더라도 "에셋 구매 = 완성 화면"은 아니다. 현재 Three.js 씬 기준으로는 모델 변환, 크기 정규화, 충돌 영역, 조명, 카메라 프레이밍, 라이선스 문서화를 같은 PR에서 처리해야 한다.
 
 ## 디렉토리 기준
 

--- a/frontend/src/components/library/BookshelfInteraction.tsx
+++ b/frontend/src/components/library/BookshelfInteraction.tsx
@@ -280,7 +280,7 @@ export default function BookshelfInteraction({
               onClick={() => {
                 closePanel();
               }}
-              className="inline-flex min-h-10 items-center justify-center rounded border border-sand bg-warm-white px-4 py-2 text-center text-sm font-semibold leading-none text-bark"
+              className="inline-flex min-h-10 items-center justify-center px-4 text-center text-sm font-semibold leading-none text-bark hover:text-bark"
             >
               {LIBRARY_LABELS.close}
             </button>
@@ -444,7 +444,7 @@ export default function BookshelfInteraction({
                 onClick={() => {
                   setOpenedLetter(null);
                 }}
-                className="inline-flex min-h-10 items-center justify-center rounded border border-sand bg-warm-white px-4 py-2 text-center text-sm font-semibold leading-none text-bark-muted hover:text-bark"
+                className="inline-flex min-h-10 items-center justify-center px-4 text-center text-sm font-semibold leading-none text-bark-muted hover:text-bark"
               >
                 {LIBRARY_LABELS.close}
               </button>

--- a/frontend/src/components/library/BookshelfInteraction.tsx
+++ b/frontend/src/components/library/BookshelfInteraction.tsx
@@ -255,7 +255,7 @@ export default function BookshelfInteraction({
         onClick={() => {
           setOpen(true);
         }}
-        className="h-12 rounded border-2 border-cream bg-bark px-4 text-sm font-semibold text-cream shadow-xl"
+        className="inline-flex min-h-12 items-center justify-center rounded border-2 border-cream bg-bark px-4 py-2 text-center text-sm font-semibold text-cream shadow-xl"
       >
         {LIBRARY_LABELS.bookshelfAction}
       </button>
@@ -280,7 +280,7 @@ export default function BookshelfInteraction({
               onClick={() => {
                 closePanel();
               }}
-              className="text-sm font-semibold text-bark"
+              className="inline-flex min-h-10 items-center justify-center rounded border border-sand bg-warm-white px-4 py-2 text-center text-sm font-semibold leading-none text-bark"
             >
               {LIBRARY_LABELS.close}
             </button>
@@ -326,7 +326,7 @@ export default function BookshelfInteraction({
                       onClick={() => {
                         setLetterPage((current) => Math.max(0, current - 1));
                       }}
-                      className="rounded border border-sand px-3 py-2 text-sm disabled:opacity-40"
+                      className="inline-flex min-h-10 items-center justify-center rounded border border-sand bg-warm-white px-4 py-2 text-center text-sm font-semibold disabled:opacity-40"
                     >
                       이전
                     </button>
@@ -339,7 +339,7 @@ export default function BookshelfInteraction({
                       onClick={() => {
                         setLetterPage((current) => Math.min(letterPageCount - 1, current + 1));
                       }}
-                      className="rounded border border-sand px-3 py-2 text-sm disabled:opacity-40"
+                      className="inline-flex min-h-10 items-center justify-center rounded border border-sand bg-warm-white px-4 py-2 text-center text-sm font-semibold disabled:opacity-40"
                     >
                       다음
                     </button>
@@ -369,7 +369,7 @@ export default function BookshelfInteraction({
                     <button
                       type="submit"
                       disabled={sendingHeart}
-                      className="rounded bg-bark px-3 py-2 text-sm font-semibold text-cream disabled:opacity-60"
+                      className="inline-flex min-h-10 items-center justify-center rounded bg-bark px-4 py-2 text-center text-sm font-semibold text-cream disabled:opacity-60"
                     >
                       {LIBRARY_LABELS.sendHeart}
                     </button>
@@ -401,7 +401,7 @@ export default function BookshelfInteraction({
                   onClick={() => {
                     setPage((current) => Math.max(0, current - 1));
                   }}
-                  className="rounded border border-sand px-3 py-2 text-sm disabled:opacity-40"
+                  className="inline-flex min-h-10 items-center justify-center rounded border border-sand bg-warm-white px-4 py-2 text-center text-sm font-semibold disabled:opacity-40"
                 >
                   이전
                 </button>
@@ -414,7 +414,7 @@ export default function BookshelfInteraction({
                   onClick={() => {
                     setPage((current) => Math.min(pageCount - 1, current + 1));
                   }}
-                  className="rounded border border-sand px-3 py-2 text-sm disabled:opacity-40"
+                  className="inline-flex min-h-10 items-center justify-center rounded border border-sand bg-warm-white px-4 py-2 text-center text-sm font-semibold disabled:opacity-40"
                 >
                   다음
                 </button>
@@ -444,7 +444,7 @@ export default function BookshelfInteraction({
                 onClick={() => {
                   setOpenedLetter(null);
                 }}
-                className="text-sm font-semibold text-bark-muted hover:text-bark"
+                className="inline-flex min-h-10 items-center justify-center rounded border border-sand bg-warm-white px-4 py-2 text-center text-sm font-semibold leading-none text-bark-muted hover:text-bark"
               >
                 {LIBRARY_LABELS.close}
               </button>

--- a/frontend/src/components/library/LibrarianInteraction.tsx
+++ b/frontend/src/components/library/LibrarianInteraction.tsx
@@ -106,7 +106,7 @@ export default function LibrarianInteraction({ near, onSubmitBook }: LibrarianIn
                 setOpen(false);
                 setMessage('');
               }}
-              className="inline-flex min-h-10 items-center justify-center rounded border border-sand bg-warm-white px-4 py-2 text-center text-sm font-semibold leading-none text-bark-muted"
+              className="inline-flex min-h-10 items-center justify-center px-4 text-center text-sm font-semibold leading-none text-bark-muted hover:text-bark"
             >
               {LIBRARY_LABELS.close}
             </button>

--- a/frontend/src/components/library/LibrarianInteraction.tsx
+++ b/frontend/src/components/library/LibrarianInteraction.tsx
@@ -106,7 +106,7 @@ export default function LibrarianInteraction({ near, onSubmitBook }: LibrarianIn
                 setOpen(false);
                 setMessage('');
               }}
-              className="inline-flex min-h-9 items-center justify-center rounded border border-sand bg-warm-white px-3 py-2 text-sm font-semibold leading-none text-bark-muted"
+              className="inline-flex min-h-10 items-center justify-center rounded border border-sand bg-warm-white px-4 py-2 text-center text-sm font-semibold leading-none text-bark-muted"
             >
               {LIBRARY_LABELS.close}
             </button>

--- a/frontend/src/components/library/LibrarianInteraction.tsx
+++ b/frontend/src/components/library/LibrarianInteraction.tsx
@@ -106,7 +106,7 @@ export default function LibrarianInteraction({ near, onSubmitBook }: LibrarianIn
                 setOpen(false);
                 setMessage('');
               }}
-              className="text-sm text-bark-muted"
+              className="inline-flex min-h-9 items-center justify-center rounded border border-sand bg-warm-white px-3 py-2 text-sm font-semibold leading-none text-bark-muted"
             >
               {LIBRARY_LABELS.close}
             </button>
@@ -118,7 +118,7 @@ export default function LibrarianInteraction({ near, onSubmitBook }: LibrarianIn
                 type="button"
                 onClick={handleCounseling}
                 disabled={!!pending}
-                className="rounded bg-bark px-3 py-2 text-cream"
+                className="inline-flex min-h-10 items-center justify-center rounded bg-bark px-4 py-2 text-center text-sm font-semibold text-cream"
               >
                 {LIBRARY_LABELS.counseling}
               </button>
@@ -127,7 +127,7 @@ export default function LibrarianInteraction({ near, onSubmitBook }: LibrarianIn
                 onClick={() => {
                   setMode('write');
                 }}
-                className="rounded bg-sand px-3 py-2 text-bark"
+                className="inline-flex min-h-10 items-center justify-center rounded bg-sand px-4 py-2 text-center text-sm font-semibold text-bark"
               >
                 {LIBRARY_LABELS.leaveBook}
               </button>
@@ -161,7 +161,7 @@ export default function LibrarianInteraction({ near, onSubmitBook }: LibrarianIn
               <button
                 type="submit"
                 disabled={pending === 'submit'}
-                className="rounded bg-bark px-3 py-2 text-cream"
+                className="inline-flex min-h-10 items-center justify-center rounded bg-bark px-4 py-2 text-center text-sm font-semibold text-cream"
               >
                 사서에게 맡기기
               </button>

--- a/frontend/src/components/library/LibraryOverlay.test.tsx
+++ b/frontend/src/components/library/LibraryOverlay.test.tsx
@@ -240,6 +240,29 @@ describe('LibrarianInteraction', () => {
     expect(screen.getByRole('button', { name: /고민이 있으신가요/ })).toBeInTheDocument();
   });
 
+  it('renders librarian panel action buttons with padded centered controls', async () => {
+    const user = userEvent.setup();
+
+    render(<LibrarianInteraction near={true} onSubmitBook={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /고민이 있으신가요/ }));
+
+    expect(screen.getByRole('button', { name: LIBRARY_LABELS.close })).toHaveClass(
+      'inline-flex',
+      'items-center',
+      'justify-center',
+      'px-3',
+      'py-2',
+    );
+    expect(screen.getByRole('button', { name: LIBRARY_LABELS.counseling })).toHaveClass(
+      'inline-flex',
+      'items-center',
+      'justify-center',
+      'px-4',
+      'py-2',
+    );
+  });
+
   it('clears previous counseling feedback when the panel is reopened', async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/components/library/LibraryOverlay.test.tsx
+++ b/frontend/src/components/library/LibraryOverlay.test.tsx
@@ -251,8 +251,9 @@ describe('LibrarianInteraction', () => {
       'inline-flex',
       'items-center',
       'justify-center',
-      'px-3',
+      'px-4',
       'py-2',
+      'min-h-10',
     );
     expect(screen.getByRole('button', { name: LIBRARY_LABELS.counseling })).toHaveClass(
       'inline-flex',
@@ -777,6 +778,39 @@ describe('BookshelfInteraction', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders bookshelf panel controls with padded centered buttons', async () => {
+    const user = userEvent.setup();
+    const books = Array.from({ length: 9 }, (_, index) => makeBook(index + 1));
+
+    render(
+      <BookshelfInteraction
+        near={true}
+        books={books}
+        onSelectBook={vi.fn().mockResolvedValue(makeSelectedBook(1))}
+        onSendHeart={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: LIBRARY_LABELS.bookshelfAction }));
+
+    expect(screen.getByRole('button', { name: LIBRARY_LABELS.close })).toHaveClass(
+      'inline-flex',
+      'min-h-10',
+      'items-center',
+      'justify-center',
+      'px-4',
+      'py-2',
+    );
+    expect(screen.getByRole('button', { name: '다음' })).toHaveClass(
+      'inline-flex',
+      'min-h-10',
+      'items-center',
+      'justify-center',
+      'px-4',
+      'py-2',
+    );
+  });
+
   it('selecting a book calls onSelectBook with the book id', async () => {
     const user = userEvent.setup();
     const onSelectBook = vi.fn().mockResolvedValue(makeSelectedBook(2));
@@ -872,6 +906,14 @@ describe('BookshelfInteraction', () => {
     );
     expect(letterDialog.querySelector('time')).toHaveClass('shrink-0');
     expect(onReadReceivedLetters).toHaveBeenCalledTimes(1);
+    expect(within(letterDialog).getByRole('button', { name: LIBRARY_LABELS.close })).toHaveClass(
+      'inline-flex',
+      'min-h-10',
+      'items-center',
+      'justify-center',
+      'px-4',
+      'py-2',
+    );
     await user.click(within(letterDialog).getByRole('button', { name: LIBRARY_LABELS.close }));
 
     await user.click(screen.getByRole('button', { name: '\uB2E4\uC74C' }));

--- a/frontend/src/components/library/LibraryOverlay.test.tsx
+++ b/frontend/src/components/library/LibraryOverlay.test.tsx
@@ -252,8 +252,11 @@ describe('LibrarianInteraction', () => {
       'items-center',
       'justify-center',
       'px-4',
-      'py-2',
       'min-h-10',
+    );
+    expect(screen.getByRole('button', { name: LIBRARY_LABELS.close })).not.toHaveClass(
+      'border',
+      'bg-warm-white',
     );
     expect(screen.getByRole('button', { name: LIBRARY_LABELS.counseling })).toHaveClass(
       'inline-flex',
@@ -799,7 +802,10 @@ describe('BookshelfInteraction', () => {
       'items-center',
       'justify-center',
       'px-4',
-      'py-2',
+    );
+    expect(screen.getByRole('button', { name: LIBRARY_LABELS.close })).not.toHaveClass(
+      'border',
+      'bg-warm-white',
     );
     expect(screen.getByRole('button', { name: '다음' })).toHaveClass(
       'inline-flex',
@@ -912,8 +918,10 @@ describe('BookshelfInteraction', () => {
       'items-center',
       'justify-center',
       'px-4',
-      'py-2',
     );
+    expect(
+      within(letterDialog).getByRole('button', { name: LIBRARY_LABELS.close }),
+    ).not.toHaveClass('border', 'bg-warm-white');
     await user.click(within(letterDialog).getByRole('button', { name: LIBRARY_LABELS.close }));
 
     await user.click(screen.getByRole('button', { name: '\uB2E4\uC74C' }));

--- a/frontend/src/three/SceneManager.ts
+++ b/frontend/src/three/SceneManager.ts
@@ -179,6 +179,9 @@ export class SceneManager {
       // collision: 마을은 숲 wall 안, 도서관은 벽 안 (간단히 Box clamp)
       if (this.active === 'village') {
         sceneObj.character.clampToCircle(0, 0, VILLAGE.FOREST_WALL_RADIUS - 1);
+        if (sceneObj instanceof VillageScene) {
+          sceneObj.resolveCollisions();
+        }
       } else {
         // 도서관: -7 ~ 7 (x), -6 ~ 6 (z)
         const p = sceneObj.character.position;

--- a/frontend/src/three/SceneManager.ts
+++ b/frontend/src/three/SceneManager.ts
@@ -184,6 +184,9 @@ export class SceneManager {
         const p = sceneObj.character.position;
         p.x = Math.max(-6.5, Math.min(6.5, p.x));
         p.z = Math.max(-5.5, Math.min(5.8, p.z));
+        if (sceneObj instanceof LibraryScene) {
+          sceneObj.resolveCollisions();
+        }
       }
 
       // 진입·퇴장 트리거

--- a/frontend/src/three/collision.test.ts
+++ b/frontend/src/three/collision.test.ts
@@ -1,0 +1,23 @@
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { resolveBoxCollisions } from './collision';
+
+describe('resolveBoxCollisions', () => {
+  it('pushes a point out of the nearest box face with clearance', () => {
+    const position = new THREE.Vector3(0, 0, -2);
+
+    resolveBoxCollisions(position, [{ minX: -1.35, maxX: 1.35, minZ: -2.75, maxZ: -1.25 }]);
+
+    expect(position.z).toBeCloseTo(-1.17);
+  });
+
+  it('leaves a point outside all boxes unchanged', () => {
+    const position = new THREE.Vector3(3, 0, 3);
+
+    resolveBoxCollisions(position, [{ minX: -1, maxX: 1, minZ: -1, maxZ: 1 }]);
+
+    expect(position.x).toBe(3);
+    expect(position.z).toBe(3);
+  });
+});

--- a/frontend/src/three/collision.ts
+++ b/frontend/src/three/collision.ts
@@ -1,0 +1,42 @@
+import * as THREE from 'three';
+
+export interface BoxCollider {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+}
+
+const DEFAULT_COLLISION_CLEARANCE = 0.08;
+
+export function resolveBoxCollisions(
+  position: THREE.Vector3,
+  boxes: readonly BoxCollider[],
+  clearance = DEFAULT_COLLISION_CLEARANCE,
+): void {
+  for (const box of boxes) {
+    if (
+      position.x < box.minX ||
+      position.x > box.maxX ||
+      position.z < box.minZ ||
+      position.z > box.maxZ
+    ) {
+      continue;
+    }
+
+    const pushLeft = Math.abs(position.x - box.minX);
+    const pushRight = Math.abs(box.maxX - position.x);
+    const pushBack = Math.abs(position.z - box.minZ);
+    const pushFront = Math.abs(box.maxZ - position.z);
+    const minPush = Math.min(pushLeft, pushRight, pushBack, pushFront);
+
+    if (minPush === pushLeft) {
+      position.x = box.minX - clearance;
+    } else if (minPush === pushRight) {
+      position.x = box.maxX + clearance;
+    } else {
+      const centerZ = (box.minZ + box.maxZ) / 2;
+      position.z = position.z < centerZ ? box.minZ - clearance : box.maxZ + clearance;
+    }
+  }
+}

--- a/frontend/src/three/scenes/LibraryScene.test.ts
+++ b/frontend/src/three/scenes/LibraryScene.test.ts
@@ -37,4 +37,29 @@ describe('LibraryScene', () => {
 
     expect(scene.isNearBookshelf()).toBe(true);
   });
+
+  it('renders the librarian as a cohesive owl keeper marker', () => {
+    const scene = new LibraryScene();
+    const roles: string[] = [];
+
+    scene.scene.traverse((obj) => {
+      if (obj.userData.libraryRole) {
+        roles.push(String(obj.userData.libraryRole));
+      }
+    });
+
+    expect(roles).toContain('librarian-owl-keeper');
+  });
+
+  it('keeps the character out of furniture and bookshelf collision boxes', () => {
+    const scene = new LibraryScene();
+
+    scene.character.position.set(0, 0, -2);
+    scene.resolveCollisions();
+    expect(scene.character.position.z).toBeGreaterThan(-1.25);
+
+    scene.character.position.set(5.5, 0, -5);
+    scene.resolveCollisions();
+    expect(scene.character.position.z < -5.45 || scene.character.position.z > -4.35).toBe(true);
+  });
 });

--- a/frontend/src/three/scenes/LibraryScene.ts
+++ b/frontend/src/three/scenes/LibraryScene.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 
 import { Character } from '../character/Character';
+import { type BoxCollider, resolveBoxCollisions } from '../collision';
 import { CAMERA } from '../constants';
 import { applyWarmLighting } from '../lighting';
 
@@ -17,8 +18,7 @@ export class LibraryScene {
   private readonly librarianAnchor = new THREE.Vector3(0, 0, -2.6);
   private readonly bookshelfXs = [-5.5, -3.3, -1.1, 1.1, 3.3, 5.5];
   private readonly bookshelfAnchors = this.bookshelfXs.map((x) => new THREE.Vector3(x, 0, -5.1));
-  private readonly collisionBoxes: { minX: number; maxX: number; minZ: number; maxZ: number }[] =
-    [];
+  private readonly collisionBoxes: BoxCollider[] = [];
   private readonly interactionRadius = 1.8;
   private readonly exitZ = 5; // 입구쪽 (남)
 
@@ -388,25 +388,6 @@ export class LibraryScene {
   }
 
   resolveCollisions(): void {
-    const p = this.character.position;
-    for (const box of this.collisionBoxes) {
-      if (p.x < box.minX || p.x > box.maxX || p.z < box.minZ || p.z > box.maxZ) continue;
-
-      const pushLeft = Math.abs(p.x - box.minX);
-      const pushRight = Math.abs(box.maxX - p.x);
-      const pushBack = Math.abs(p.z - box.minZ);
-      const pushFront = Math.abs(box.maxZ - p.z);
-      const minPush = Math.min(pushLeft, pushRight, pushBack, pushFront);
-      const clearance = 0.08;
-
-      if (minPush === pushLeft) {
-        p.x = box.minX - clearance;
-      } else if (minPush === pushRight) {
-        p.x = box.maxX + clearance;
-      } else {
-        const centerZ = (box.minZ + box.maxZ) / 2;
-        p.z = p.z < centerZ ? box.minZ - clearance : box.maxZ + clearance;
-      }
-    }
+    resolveBoxCollisions(this.character.position, this.collisionBoxes);
   }
 }

--- a/frontend/src/three/scenes/LibraryScene.ts
+++ b/frontend/src/three/scenes/LibraryScene.ts
@@ -17,6 +17,8 @@ export class LibraryScene {
   private readonly librarianAnchor = new THREE.Vector3(0, 0, -2.6);
   private readonly bookshelfXs = [-5.5, -3.3, -1.1, 1.1, 3.3, 5.5];
   private readonly bookshelfAnchors = this.bookshelfXs.map((x) => new THREE.Vector3(x, 0, -5.1));
+  private readonly collisionBoxes: { minX: number; maxX: number; minZ: number; maxZ: number }[] =
+    [];
   private readonly interactionRadius = 1.8;
   private readonly exitZ = 5; // 입구쪽 (남)
 
@@ -253,6 +255,7 @@ export class LibraryScene {
       shelf.position.set(x, 1.9, -5);
       shelf.castShadow = true;
       this.scene.add(shelf);
+      this.collisionBoxes.push({ minX: x - 1.1, maxX: x + 1.1, minZ: -5.45, maxZ: -4.35 });
 
       // 책 색깔 layer (Step 4 에서 글 list 결로 박음)
       for (let row = 0; row < 5; row += 1) {
@@ -279,6 +282,7 @@ export class LibraryScene {
     desk.position.set(0, 0.85, -2);
     desk.castShadow = true;
     this.scene.add(desk);
+    this.collisionBoxes.push({ minX: -1.35, maxX: 1.35, minZ: -2.75, maxZ: -1.25 });
 
     // 책상 다리
     const legMaterial = new THREE.MeshLambertMaterial({ color: 0x6b4226 });
@@ -299,62 +303,63 @@ export class LibraryScene {
     note.position.set(0, 0.91, -2);
     this.scene.add(note);
 
-    const body = new THREE.Mesh(
-      new THREE.CapsuleGeometry(0.32, 0.68, 4, 8),
-      new THREE.MeshLambertMaterial({ color: 0x526f62 }),
-    );
-    body.position.set(0.65, 1.28, -2.15);
+    this.buildLibrarianOwlKeeper();
+  }
+
+  private buildLibrarianOwlKeeper(): void {
+    const group = new THREE.Group();
+    group.userData.libraryRole = 'librarian-owl-keeper';
+
+    const featherMaterial = new THREE.MeshLambertMaterial({ color: 0x7b5a3a });
+    const faceMaterial = new THREE.MeshLambertMaterial({ color: 0xf1dfbd });
+    const wingMaterial = new THREE.MeshLambertMaterial({ color: 0x5f432c });
+    const eyeMaterial = new THREE.MeshBasicMaterial({ color: 0x1f1a14 });
+    const beakMaterial = new THREE.MeshLambertMaterial({ color: 0xe0a542 });
+    const bookMaterial = new THREE.MeshLambertMaterial({ color: 0x8c4a3a });
+
+    const body = new THREE.Mesh(new THREE.SphereGeometry(0.42, 18, 14), featherMaterial);
+    body.position.set(0, 1.25, 0);
+    body.scale.set(0.9, 1.15, 0.78);
     body.castShadow = true;
-    this.scene.add(body);
+    group.add(body);
 
-    const apron = new THREE.Mesh(
-      new THREE.BoxGeometry(0.38, 0.5, 0.08),
-      new THREE.MeshLambertMaterial({ color: 0xf0dfbf }),
-    );
-    apron.position.set(0.65, 1.24, -1.9);
-    apron.rotation.x = -0.08;
-    this.scene.add(apron);
+    const face = new THREE.Mesh(new THREE.SphereGeometry(0.28, 16, 10), faceMaterial);
+    face.position.set(0, 1.58, 0.23);
+    face.scale.set(1.25, 0.82, 0.24);
+    group.add(face);
 
-    const head = new THREE.Mesh(
-      new THREE.SphereGeometry(0.23, 16, 12),
-      new THREE.MeshLambertMaterial({ color: 0xf1c6a8 }),
-    );
-    head.position.set(0.65, 1.82, -2.15);
-    head.castShadow = true;
-    this.scene.add(head);
+    for (const x of [-0.16, 0.16]) {
+      const eye = new THREE.Mesh(new THREE.SphereGeometry(0.055, 8, 6), eyeMaterial);
+      eye.position.set(x, 1.62, 0.46);
+      group.add(eye);
 
-    const hair = new THREE.Mesh(
-      new THREE.SphereGeometry(0.245, 16, 12),
-      new THREE.MeshLambertMaterial({ color: 0x4a3525 }),
-    );
-    hair.position.set(0.65, 1.9, -2.2);
-    hair.scale.set(1.05, 0.72, 0.9);
-    this.scene.add(hair);
-
-    const bun = new THREE.Mesh(
-      new THREE.SphereGeometry(0.12, 12, 8),
-      new THREE.MeshLambertMaterial({ color: 0x4a3525 }),
-    );
-    bun.position.set(0.65, 1.9, -2.43);
-    this.scene.add(bun);
-
-    const glassesMaterial = new THREE.MeshBasicMaterial({ color: 0x2f2a24 });
-    for (const gx of [0.56, 0.74]) {
-      const lens = new THREE.Mesh(new THREE.TorusGeometry(0.055, 0.008, 6, 12), glassesMaterial);
-      lens.position.set(gx, 1.83, -1.94);
-      this.scene.add(lens);
+      const brow = new THREE.Mesh(new THREE.ConeGeometry(0.12, 0.2, 3), wingMaterial);
+      brow.position.set(x, 1.77, 0.28);
+      brow.rotation.z = x < 0 ? -0.35 : 0.35;
+      group.add(brow);
     }
-    const bridge = new THREE.Mesh(new THREE.BoxGeometry(0.08, 0.01, 0.01), glassesMaterial);
-    bridge.position.set(0.65, 1.83, -1.94);
-    this.scene.add(bridge);
 
-    const heldBook = new THREE.Mesh(
-      new THREE.BoxGeometry(0.34, 0.06, 0.46),
-      new THREE.MeshLambertMaterial({ color: 0x8c4a3a }),
-    );
-    heldBook.position.set(0.28, 1.2, -1.82);
-    heldBook.rotation.set(0.2, -0.35, 0.1);
-    this.scene.add(heldBook);
+    const beak = new THREE.Mesh(new THREE.ConeGeometry(0.065, 0.16, 4), beakMaterial);
+    beak.position.set(0, 1.52, 0.5);
+    beak.rotation.x = Math.PI / 2;
+    group.add(beak);
+
+    for (const x of [-0.34, 0.34]) {
+      const wing = new THREE.Mesh(new THREE.SphereGeometry(0.18, 10, 8), wingMaterial);
+      wing.position.set(x, 1.2, 0.05);
+      wing.scale.set(0.62, 1.55, 0.45);
+      wing.rotation.z = x < 0 ? 0.18 : -0.18;
+      group.add(wing);
+    }
+
+    const book = new THREE.Mesh(new THREE.BoxGeometry(0.52, 0.08, 0.36), bookMaterial);
+    book.position.set(-0.05, 1.04, 0.46);
+    book.rotation.x = 0.28;
+    group.add(book);
+
+    group.position.set(0.65, 0, -2.22);
+    group.rotation.y = -0.08;
+    this.scene.add(group);
   }
 
   updateCamera(camera: THREE.PerspectiveCamera): void {
@@ -380,5 +385,28 @@ export class LibraryScene {
 
   isAtExit(): boolean {
     return this.character.position.z > this.exitZ;
+  }
+
+  resolveCollisions(): void {
+    const p = this.character.position;
+    for (const box of this.collisionBoxes) {
+      if (p.x < box.minX || p.x > box.maxX || p.z < box.minZ || p.z > box.maxZ) continue;
+
+      const pushLeft = Math.abs(p.x - box.minX);
+      const pushRight = Math.abs(box.maxX - p.x);
+      const pushBack = Math.abs(p.z - box.minZ);
+      const pushFront = Math.abs(box.maxZ - p.z);
+      const minPush = Math.min(pushLeft, pushRight, pushBack, pushFront);
+      const clearance = 0.08;
+
+      if (minPush === pushLeft) {
+        p.x = box.minX - clearance;
+      } else if (minPush === pushRight) {
+        p.x = box.maxX + clearance;
+      } else {
+        const centerZ = (box.minZ + box.maxZ) / 2;
+        p.z = p.z < centerZ ? box.minZ - clearance : box.maxZ + clearance;
+      }
+    }
   }
 }

--- a/frontend/src/three/scenes/VillageScene.test.ts
+++ b/frontend/src/three/scenes/VillageScene.test.ts
@@ -1,0 +1,19 @@
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+
+import { VillageScene } from './VillageScene';
+
+describe('VillageScene', () => {
+  it('renders the library room sign with a texture label', () => {
+    const village = new VillageScene();
+    let signTexture: unknown = null;
+
+    village.scene.traverse((obj) => {
+      if (obj instanceof THREE.Mesh && obj.userData.villageRole === 'library-room-sign') {
+        signTexture = (obj.material as THREE.MeshLambertMaterial).map;
+      }
+    });
+
+    expect(signTexture).toBeInstanceOf(THREE.CanvasTexture);
+  });
+});

--- a/frontend/src/three/scenes/VillageScene.test.ts
+++ b/frontend/src/three/scenes/VillageScene.test.ts
@@ -16,4 +16,18 @@ describe('VillageScene', () => {
 
     expect(signTexture).toBeInstanceOf(THREE.CanvasTexture);
   });
+
+  it('keeps the character out of village signboards and the library shell', () => {
+    const village = new VillageScene();
+
+    village.character.position.set(-4.8, 0, 21);
+    village.resolveCollisions();
+    expect(village.character.position.z < 20.15 || village.character.position.z > 21.85).toBe(true);
+
+    village.character.position.set(0, 0, -27);
+    village.resolveCollisions();
+    expect(village.character.position.z < -30.25 || village.character.position.z > -23.75).toBe(
+      true,
+    );
+  });
 });

--- a/frontend/src/three/scenes/VillageScene.ts
+++ b/frontend/src/three/scenes/VillageScene.ts
@@ -5,6 +5,7 @@ import type { Suggestion, VillageDashboard } from '@/types/village-board';
 
 import { Character } from '../character/Character';
 import { RemotePlayer } from '../character/RemotePlayer';
+import { type BoxCollider, resolveBoxCollisions } from '../collision';
 import { CAMERA, VILLAGE } from '../constants';
 import { applyWarmLighting } from '../lighting';
 import { buildVillageDecor, type VillageDecor } from './villageDecor';
@@ -24,7 +25,7 @@ export class VillageScene {
   private readonly decor: VillageDecor;
   private readonly dashboardBoard = new THREE.Vector3(-4.8, 0, VILLAGE.ENTRY_Z - 11);
   private readonly suggestionBoard = new THREE.Vector3(4.8, 0, VILLAGE.ENTRY_Z - 11);
-  private readonly collisionBoxes: { minX: number; maxX: number; minZ: number; maxZ: number }[] = [
+  private readonly collisionBoxes: BoxCollider[] = [
     { minX: -4.35, maxX: 4.35, minZ: VILLAGE.LIBRARY_Z - 3.25, maxZ: VILLAGE.LIBRARY_Z + 3.25 },
     { minX: -7.25, maxX: -2.35, minZ: VILLAGE.ENTRY_Z - 11.85, maxZ: VILLAGE.ENTRY_Z - 10.15 },
     { minX: 2.35, maxX: 7.25, minZ: VILLAGE.ENTRY_Z - 11.85, maxZ: VILLAGE.ENTRY_Z - 10.15 },
@@ -574,25 +575,7 @@ export class VillageScene {
 
   resolveCollisions(): void {
     const p = this.character.position;
-    for (const box of this.collisionBoxes) {
-      if (p.x < box.minX || p.x > box.maxX || p.z < box.minZ || p.z > box.maxZ) continue;
-
-      const pushLeft = Math.abs(p.x - box.minX);
-      const pushRight = Math.abs(box.maxX - p.x);
-      const pushBack = Math.abs(p.z - box.minZ);
-      const pushFront = Math.abs(box.maxZ - p.z);
-      const minPush = Math.min(pushLeft, pushRight, pushBack, pushFront);
-      const clearance = 0.08;
-
-      if (minPush === pushLeft) {
-        p.x = box.minX - clearance;
-      } else if (minPush === pushRight) {
-        p.x = box.maxX + clearance;
-      } else {
-        const centerZ = (box.minZ + box.maxZ) / 2;
-        p.z = p.z < centerZ ? box.minZ - clearance : box.maxZ + clearance;
-      }
-    }
+    resolveBoxCollisions(p, this.collisionBoxes);
     this.decor.resolveCollisions(p);
   }
 

--- a/frontend/src/three/scenes/VillageScene.ts
+++ b/frontend/src/three/scenes/VillageScene.ts
@@ -24,6 +24,11 @@ export class VillageScene {
   private readonly decor: VillageDecor;
   private readonly dashboardBoard = new THREE.Vector3(-4.8, 0, VILLAGE.ENTRY_Z - 11);
   private readonly suggestionBoard = new THREE.Vector3(4.8, 0, VILLAGE.ENTRY_Z - 11);
+  private readonly collisionBoxes: { minX: number; maxX: number; minZ: number; maxZ: number }[] = [
+    { minX: -4.35, maxX: 4.35, minZ: VILLAGE.LIBRARY_Z - 3.25, maxZ: VILLAGE.LIBRARY_Z + 3.25 },
+    { minX: -7.25, maxX: -2.35, minZ: VILLAGE.ENTRY_Z - 11.85, maxZ: VILLAGE.ENTRY_Z - 10.15 },
+    { minX: 2.35, maxX: 7.25, minZ: VILLAGE.ENTRY_Z - 11.85, maxZ: VILLAGE.ENTRY_Z - 10.15 },
+  ];
   private dashboardBoardTexture: THREE.CanvasTexture | null = null;
   private suggestionBoardTexture: THREE.CanvasTexture | null = null;
   private elapsed = 0;
@@ -565,6 +570,29 @@ export class VillageScene {
 
   isNearSuggestionBoard(): boolean {
     return this.character.position.distanceTo(this.suggestionBoard) < VILLAGE.BOARD_TRIGGER_RADIUS;
+  }
+
+  resolveCollisions(): void {
+    const p = this.character.position;
+    for (const box of this.collisionBoxes) {
+      if (p.x < box.minX || p.x > box.maxX || p.z < box.minZ || p.z > box.maxZ) continue;
+
+      const pushLeft = Math.abs(p.x - box.minX);
+      const pushRight = Math.abs(box.maxX - p.x);
+      const pushBack = Math.abs(p.z - box.minZ);
+      const pushFront = Math.abs(box.maxZ - p.z);
+      const minPush = Math.min(pushLeft, pushRight, pushBack, pushFront);
+      const clearance = 0.08;
+
+      if (minPush === pushLeft) {
+        p.x = box.minX - clearance;
+      } else if (minPush === pushRight) {
+        p.x = box.maxX + clearance;
+      } else {
+        const centerZ = (box.minZ + box.maxZ) / 2;
+        p.z = p.z < centerZ ? box.minZ - clearance : box.maxZ + clearance;
+      }
+    }
   }
 
   /**

--- a/frontend/src/three/scenes/VillageScene.ts
+++ b/frontend/src/three/scenes/VillageScene.ts
@@ -215,11 +215,13 @@ export class VillageScene {
     this.scene.add(door);
 
     // 도서관 표지판
+    const signTexture = this.createLibraryRoomSignTexture();
     const sign = new THREE.Mesh(
       new THREE.BoxGeometry(2.4, 0.6, 0.1),
-      new THREE.MeshLambertMaterial({ color: 0xe8d5a3 }),
+      new THREE.MeshLambertMaterial({ color: 0xe8d5a3, map: signTexture }),
     );
     sign.position.set(0, 3.2, VILLAGE.LIBRARY_Z + 3.05);
+    sign.userData.villageRole = 'library-room-sign';
     this.scene.add(sign);
 
     // 창문 2개 — 안에 불이 켜진 따뜻한 노란빛 (들어가 보고 싶은 신호)
@@ -410,6 +412,24 @@ export class VillageScene {
       wrapText(ctx, suggestion.body, 610, 2).forEach((line, index) => {
         drawText(ctx, line, 100, 248 + index * 38, '500 28px sans-serif', '#5f432d');
       });
+    });
+  }
+
+  private createLibraryRoomSignTexture(): THREE.CanvasTexture {
+    return this.createBoardTexture((ctx, canvas) => {
+      ctx.fillStyle = '#e8d5a3';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.strokeStyle = '#6b4a2e';
+      ctx.lineWidth = 22;
+      ctx.strokeRect(24, 24, canvas.width - 48, canvas.height - 48);
+      drawCenteredText(
+        ctx,
+        '사서방',
+        canvas.width / 2,
+        canvas.height / 2,
+        '800 132px sans-serif',
+        '#3f2b1c',
+      );
     });
   }
 

--- a/frontend/src/three/scenes/VillageScene.ts
+++ b/frontend/src/three/scenes/VillageScene.ts
@@ -593,6 +593,7 @@ export class VillageScene {
         p.z = p.z < centerZ ? box.minZ - clearance : box.maxZ + clearance;
       }
     }
+    this.decor.resolveCollisions(p);
   }
 
   /**

--- a/frontend/src/three/scenes/villageDecor.test.ts
+++ b/frontend/src/three/scenes/villageDecor.test.ts
@@ -75,7 +75,6 @@ describe('villageDecor — 마을 데코 풀 패스', () => {
       }
     });
 
-    expect(roles).toContain('confession-mailbox');
     expect(roles).toContain('library-welcome-arch');
     expect(roles.filter((role) => role === 'letter-path-lantern')).toHaveLength(6);
     expect(roles.filter((role) => role === 'library-flower-box')).toHaveLength(2);
@@ -95,7 +94,6 @@ describe('villageDecor — 마을 데코 풀 패스', () => {
 
     expect(roles.filter((role) => role === 'fairy-mushroom')).toHaveLength(18);
     expect(roles.filter((role) => role === 'secret-trail-flower')).toHaveLength(24);
-    expect(roles.filter((role) => role === 'hanging-lantern-garland')).toHaveLength(3);
     expect(roles.filter((role) => role === 'glow-stone')).toHaveLength(10);
     expect(roles).toContain('leafy-secret-arch');
   });

--- a/frontend/src/three/scenes/villageDecor.test.ts
+++ b/frontend/src/three/scenes/villageDecor.test.ts
@@ -63,6 +63,24 @@ describe('villageDecor — 마을 데코 풀 패스', () => {
     expect(hideoutObjects).toContain('campfire-keepsake-sign');
   });
 
+  it('무료 에셋 목업용 시그니처 오브젝트가 마을 동선에 배치된다', () => {
+    const scene = new THREE.Scene();
+    buildVillageDecor(scene);
+
+    const roles: string[] = [];
+    scene.traverse((obj) => {
+      if (!(obj instanceof THREE.Object3D)) return;
+      if (obj.userData.villageDecorRole) {
+        roles.push(String(obj.userData.villageDecorRole));
+      }
+    });
+
+    expect(roles).toContain('confession-mailbox');
+    expect(roles).toContain('library-welcome-arch');
+    expect(roles.filter((role) => role === 'letter-path-lantern')).toHaveLength(6);
+    expect(roles.filter((role) => role === 'library-flower-box')).toHaveLength(2);
+  });
+
   it('입구~도서관 길 위에는 지상 데코가 없다 (동선 보호)', () => {
     const scene = new THREE.Scene();
     buildVillageDecor(scene);

--- a/frontend/src/three/scenes/villageDecor.test.ts
+++ b/frontend/src/three/scenes/villageDecor.test.ts
@@ -44,6 +44,27 @@ describe('villageDecor — 마을 데코 풀 패스', () => {
     }).not.toThrow();
   });
 
+  it('두꺼운 데코 충돌 영역에 들어간 위치를 바깥으로 밀어낸다', () => {
+    const scene = new THREE.Scene();
+    const decor = buildVillageDecor(scene);
+    const position = new THREE.Vector3(2.6, 0, 32);
+
+    decor.resolveCollisions(position);
+
+    expect(Math.hypot(position.x - 2.6, position.z - 32)).toBeGreaterThan(0.28);
+  });
+
+  it('중앙 동선의 빈 위치는 데코 충돌로 이동하지 않는다', () => {
+    const scene = new THREE.Scene();
+    const decor = buildVillageDecor(scene);
+    const position = new THREE.Vector3(0, 0, 25);
+
+    decor.resolveCollisions(position);
+
+    expect(position.x).toBe(0);
+    expect(position.z).toBe(25);
+  });
+
   it('모닥불 주변에 대화 아지트 전용 오브젝트가 결정적으로 배치된다', () => {
     const scene = new THREE.Scene();
     buildVillageDecor(scene);

--- a/frontend/src/three/scenes/villageDecor.test.ts
+++ b/frontend/src/three/scenes/villageDecor.test.ts
@@ -75,7 +75,7 @@ describe('villageDecor — 마을 데코 풀 패스', () => {
       }
     });
 
-    expect(roles).toContain('library-welcome-arch');
+    expect(roles).not.toContain('library-welcome-arch');
     expect(roles.filter((role) => role === 'letter-path-lantern')).toHaveLength(6);
     expect(roles.filter((role) => role === 'library-flower-box')).toHaveLength(2);
   });

--- a/frontend/src/three/scenes/villageDecor.test.ts
+++ b/frontend/src/three/scenes/villageDecor.test.ts
@@ -81,6 +81,25 @@ describe('villageDecor — 마을 데코 풀 패스', () => {
     expect(roles.filter((role) => role === 'library-flower-box')).toHaveLength(2);
   });
 
+  it('동화 숲속 비밀기지 분위기의 장식이 충분한 밀도로 배치된다', () => {
+    const scene = new THREE.Scene();
+    buildVillageDecor(scene);
+
+    const roles: string[] = [];
+    scene.traverse((obj) => {
+      if (!(obj instanceof THREE.Object3D)) return;
+      if (obj.userData.villageDecorRole) {
+        roles.push(String(obj.userData.villageDecorRole));
+      }
+    });
+
+    expect(roles.filter((role) => role === 'fairy-mushroom')).toHaveLength(18);
+    expect(roles.filter((role) => role === 'secret-trail-flower')).toHaveLength(24);
+    expect(roles.filter((role) => role === 'hanging-lantern-garland')).toHaveLength(3);
+    expect(roles.filter((role) => role === 'glow-stone')).toHaveLength(10);
+    expect(roles).toContain('leafy-secret-arch');
+  });
+
   it('입구~도서관 길 위에는 지상 데코가 없다 (동선 보호)', () => {
     const scene = new THREE.Scene();
     buildVillageDecor(scene);

--- a/frontend/src/three/scenes/villageDecor.ts
+++ b/frontend/src/three/scenes/villageDecor.ts
@@ -180,6 +180,219 @@ function buildFreeMockupSignatureProps(scene: THREE.Scene): void {
   buildLibraryWelcomeArch(scene);
   buildLetterPathLanterns(scene);
   buildLibraryFlowerBoxes(scene);
+  buildFairyForestHideout(scene);
+}
+
+function buildFairyForestHideout(scene: THREE.Scene): void {
+  buildFairyMushroomRing(scene);
+  buildSecretTrailFlowers(scene);
+  buildHangingLanternGarlands(scene);
+  buildGlowStones(scene);
+  buildLeafySecretArch(scene);
+}
+
+function buildFairyMushroomRing(scene: THREE.Scene): void {
+  const stemMaterial = new THREE.MeshLambertMaterial({ color: 0xf3dcc5 });
+  const capMaterials = [
+    new THREE.MeshLambertMaterial({ color: 0xe96f72 }),
+    new THREE.MeshLambertMaterial({ color: 0xf2a65a }),
+    new THREE.MeshLambertMaterial({ color: 0xc48ad8 }),
+  ];
+  const spotMaterial = new THREE.MeshLambertMaterial({ color: 0xfff2cf });
+
+  for (let i = 0; i < 18; i += 1) {
+    const angle = (i / 18) * Math.PI * 2;
+    const radius = i % 2 === 0 ? 6.2 : 6.9;
+    const group = tagDecor(new THREE.Group(), 'fairy-mushroom');
+    const scale = 0.75 + (i % 4) * 0.12;
+
+    const stem = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.09 * scale, 0.14 * scale, 0.45 * scale, 7),
+      stemMaterial,
+    );
+    stem.position.set(0, 0.22 * scale, 0);
+    stem.castShadow = true;
+    group.add(stem);
+
+    const cap = new THREE.Mesh(
+      new THREE.SphereGeometry(0.32 * scale, 10, 6, 0, Math.PI * 2, 0, Math.PI / 2),
+      capMaterials[i % capMaterials.length],
+    );
+    cap.position.set(0, 0.48 * scale, 0);
+    cap.scale.y = 0.72;
+    cap.castShadow = true;
+    group.add(cap);
+
+    for (let s = 0; s < 3; s += 1) {
+      const spot = new THREE.Mesh(new THREE.SphereGeometry(0.035 * scale, 6, 5), spotMaterial);
+      const spotAngle = (s / 3) * Math.PI * 2 + i * 0.2;
+      spot.position.set(
+        Math.cos(spotAngle) * 0.16 * scale,
+        0.63 * scale,
+        Math.sin(spotAngle) * 0.16 * scale,
+      );
+      group.add(spot);
+    }
+
+    const rawX = Math.cos(angle) * radius;
+    const safeX = Math.abs(rawX) < 2.15 ? (i % 2 === 0 ? 2.15 : -2.15) : rawX;
+    group.position.set(safeX, 0, VILLAGE.CAMPFIRE_Z + Math.sin(angle) * radius);
+    group.rotation.y = -angle;
+    scene.add(group);
+  }
+}
+
+function buildSecretTrailFlowers(scene: THREE.Scene): void {
+  const stemMaterial = new THREE.MeshLambertMaterial({ color: 0x6f9a55 });
+  const petalMaterials = [
+    new THREE.MeshLambertMaterial({ color: 0xf5a6c8 }),
+    new THREE.MeshLambertMaterial({ color: 0xffd979 }),
+    new THREE.MeshLambertMaterial({ color: 0xb9a7ff }),
+    new THREE.MeshLambertMaterial({ color: 0x9ee6c8 }),
+  ];
+  const positions: [number, number][] = [];
+  for (let i = 0; i < 12; i += 1) {
+    const z = VILLAGE.ENTRY_Z - 4 - i * 4.4;
+    positions.push([-2.25 - (i % 3) * 0.22, z]);
+    positions.push([2.25 + (i % 3) * 0.22, z - 1.4]);
+  }
+
+  positions.forEach(([x, z], index) => {
+    const group = tagDecor(new THREE.Group(), 'secret-trail-flower');
+    const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.025, 0.035, 0.42, 5), stemMaterial);
+    stem.position.set(0, 0.2, 0);
+    group.add(stem);
+
+    const head = new THREE.Mesh(
+      new THREE.SphereGeometry(0.13, 7, 5),
+      petalMaterials[index % petalMaterials.length],
+    );
+    head.position.set(0, 0.46, 0);
+    group.add(head);
+
+    const leaf = new THREE.Mesh(new THREE.SphereGeometry(0.08, 6, 5), stemMaterial);
+    leaf.position.set(index % 2 === 0 ? 0.1 : -0.1, 0.3, 0);
+    leaf.scale.set(1.4, 0.55, 0.8);
+    group.add(leaf);
+
+    group.position.set(x, 0, z);
+    group.rotation.y = index * 0.43;
+    scene.add(group);
+  });
+}
+
+function buildHangingLanternGarlands(scene: THREE.Scene): void {
+  const ropeMaterial = new THREE.MeshLambertMaterial({ color: 0x6b4a32 });
+  const lanternMaterial = new THREE.MeshLambertMaterial({
+    color: 0xffd890,
+    emissive: 0xffaa5a,
+    emissiveIntensity: 0.75,
+  });
+  const leafMaterial = new THREE.MeshLambertMaterial({ color: 0x5f8d52 });
+  const zSpots = [VILLAGE.ENTRY_Z - 14, VILLAGE.CAMPFIRE_Z - 4, VILLAGE.LIBRARY_Z + 13];
+
+  for (const z of zSpots) {
+    const group = tagDecor(new THREE.Group(), 'hanging-lantern-garland');
+    const rope = new THREE.Mesh(new THREE.CylinderGeometry(0.025, 0.025, 5.4, 6), ropeMaterial);
+    rope.rotation.z = Math.PI / 2;
+    rope.position.set(0, 2.25, 0);
+    group.add(rope);
+
+    for (const x of [-1.75, 0, 1.75]) {
+      const drop = new THREE.Mesh(new THREE.CylinderGeometry(0.012, 0.012, 0.45, 5), ropeMaterial);
+      drop.position.set(x, 2.02, 0);
+      group.add(drop);
+
+      const lantern = new THREE.Mesh(new THREE.SphereGeometry(0.18, 8, 6), lanternMaterial);
+      lantern.position.set(x, 1.72, 0);
+      group.add(lantern);
+    }
+
+    for (const x of [-2.25, -0.75, 0.75, 2.25]) {
+      const leaf = new THREE.Mesh(new THREE.SphereGeometry(0.12, 6, 5), leafMaterial);
+      leaf.position.set(x, 2.33, 0);
+      leaf.scale.set(1.5, 0.45, 0.8);
+      group.add(leaf);
+    }
+
+    group.position.set(0, 0, z);
+    scene.add(group);
+  }
+}
+
+function buildGlowStones(scene: THREE.Scene): void {
+  const stoneMaterial = new THREE.MeshLambertMaterial({
+    color: 0x9fd8ff,
+    emissive: 0x6db8ff,
+    emissiveIntensity: 0.45,
+  });
+  const spots: [number, number][] = [
+    [-3.1, VILLAGE.ENTRY_Z - 9],
+    [3.15, VILLAGE.ENTRY_Z - 12],
+    [-3.35, VILLAGE.ENTRY_Z - 21],
+    [3.25, VILLAGE.ENTRY_Z - 25],
+    [-3.25, VILLAGE.CAMPFIRE_Z - 1],
+    [3.35, VILLAGE.CAMPFIRE_Z - 6],
+    [-3.1, VILLAGE.CAMPFIRE_Z - 15],
+    [3.2, VILLAGE.LIBRARY_Z + 18],
+    [-3.3, VILLAGE.LIBRARY_Z + 10],
+    [3.3, VILLAGE.LIBRARY_Z + 6],
+  ];
+
+  spots.forEach(([x, z], index) => {
+    const stone = tagDecor(
+      new THREE.Mesh(new THREE.DodecahedronGeometry(0.18 + (index % 3) * 0.04, 0), stoneMaterial),
+      'glow-stone',
+    );
+    stone.position.set(x, 0.11, z);
+    stone.rotation.set(index * 0.37, index * 0.22, 0);
+    stone.scale.set(1.25, 0.62, 1);
+    stone.castShadow = true;
+    scene.add(stone);
+  });
+}
+
+function buildLeafySecretArch(scene: THREE.Scene): void {
+  const group = tagDecor(new THREE.Group(), 'leafy-secret-arch');
+  const trunkMaterial = new THREE.MeshLambertMaterial({ color: 0x6d4a32 });
+  const leafMaterials = [
+    new THREE.MeshLambertMaterial({ color: 0x5f8d52 }),
+    new THREE.MeshLambertMaterial({ color: 0x7aa85c }),
+    new THREE.MeshLambertMaterial({ color: 0x8fbf6a }),
+  ];
+  const flowerMaterial = new THREE.MeshLambertMaterial({
+    color: 0xf3a3c7,
+    emissive: 0xc85c86,
+    emissiveIntensity: 0.2,
+  });
+
+  for (const x of [-2.75, 2.75]) {
+    const trunk = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.22, 3.0, 7), trunkMaterial);
+    trunk.position.set(x, 1.5, 0);
+    trunk.rotation.z = x < 0 ? -0.18 : 0.18;
+    trunk.castShadow = true;
+    group.add(trunk);
+  }
+
+  for (let i = 0; i < 15; i += 1) {
+    const t = i / 14;
+    const x = -2.6 + t * 5.2;
+    const y = 2.55 + Math.sin(t * Math.PI) * 0.85;
+    const leaf = new THREE.Mesh(new THREE.SphereGeometry(0.48, 8, 6), leafMaterials[i % 3]);
+    leaf.position.set(x, y, 0);
+    leaf.scale.set(1.2, 0.78, 0.95);
+    leaf.castShadow = true;
+    group.add(leaf);
+
+    if (i % 3 === 0) {
+      const flower = new THREE.Mesh(new THREE.SphereGeometry(0.09, 6, 5), flowerMaterial);
+      flower.position.set(x, y + 0.33, 0.08);
+      group.add(flower);
+    }
+  }
+
+  group.position.set(0, 0, VILLAGE.LIBRARY_Z + 9.7);
+  scene.add(group);
 }
 
 function buildConfessionMailbox(scene: THREE.Scene): void {

--- a/frontend/src/three/scenes/villageDecor.ts
+++ b/frontend/src/three/scenes/villageDecor.ts
@@ -174,6 +174,164 @@ function buildPathFence(scene: THREE.Scene): void {
   }
 }
 
+/** 무료/자체 제작 소품 패스 — 외부 유료 에셋 없이 목업의 밀도와 기억점을 만든다. */
+function buildFreeMockupSignatureProps(scene: THREE.Scene): void {
+  buildConfessionMailbox(scene);
+  buildLibraryWelcomeArch(scene);
+  buildLetterPathLanterns(scene);
+  buildLibraryFlowerBoxes(scene);
+}
+
+function buildConfessionMailbox(scene: THREE.Scene): void {
+  const group = tagDecor(new THREE.Group(), 'confession-mailbox');
+  const redMaterial = new THREE.MeshLambertMaterial({ color: 0xb94b43 });
+  const darkRedMaterial = new THREE.MeshLambertMaterial({ color: 0x81352f });
+  const woodMaterial = new THREE.MeshLambertMaterial({ color: 0x765437 });
+  const creamMaterial = new THREE.MeshLambertMaterial({ color: 0xf4e6c9 });
+
+  const post = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.95, 0.16), woodMaterial);
+  post.position.set(0, 0.48, 0);
+  post.castShadow = true;
+  group.add(post);
+
+  const box = new THREE.Mesh(new THREE.BoxGeometry(1.05, 0.48, 0.58), redMaterial);
+  box.position.set(0, 1.12, 0);
+  box.castShadow = true;
+  group.add(box);
+
+  const roof = new THREE.Mesh(new THREE.CylinderGeometry(0.3, 0.3, 1.06, 12), darkRedMaterial);
+  roof.rotation.z = Math.PI / 2;
+  roof.position.set(0, 1.38, 0);
+  roof.scale.z = 0.72;
+  roof.castShadow = true;
+  group.add(roof);
+
+  const flagPole = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.55, 0.05), woodMaterial);
+  flagPole.position.set(0.58, 1.35, 0.32);
+  group.add(flagPole);
+
+  const flag = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.24, 0.04), creamMaterial);
+  flag.position.set(0.78, 1.55, 0.32);
+  group.add(flag);
+
+  const letterSlot = new THREE.Mesh(new THREE.BoxGeometry(0.62, 0.08, 0.04), creamMaterial);
+  letterSlot.position.set(0, 1.15, 0.31);
+  group.add(letterSlot);
+
+  group.position.set(-3.7, 0, VILLAGE.ENTRY_Z - 16);
+  group.rotation.y = -0.18;
+  scene.add(group);
+}
+
+function buildLibraryWelcomeArch(scene: THREE.Scene): void {
+  const group = tagDecor(new THREE.Group(), 'library-welcome-arch');
+  const woodMaterial = new THREE.MeshLambertMaterial({ color: 0x6f4f34 });
+  const signMaterial = new THREE.MeshLambertMaterial({ color: 0xc99a62 });
+  const glowMaterial = new THREE.MeshLambertMaterial({
+    color: 0xffdf9a,
+    emissive: 0xffb85a,
+    emissiveIntensity: 0.65,
+  });
+
+  for (const x of [-2.35, 2.35]) {
+    const post = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.16, 2.7, 7), woodMaterial);
+    post.position.set(x, 1.35, 0);
+    post.castShadow = true;
+    group.add(post);
+
+    const lantern = new THREE.Mesh(new THREE.SphereGeometry(0.16, 8, 6), glowMaterial);
+    lantern.position.set(x, 2.25, 0.08);
+    group.add(lantern);
+  }
+
+  const beam = new THREE.Mesh(new THREE.BoxGeometry(5.2, 0.18, 0.2), woodMaterial);
+  beam.position.set(0, 2.62, 0);
+  beam.castShadow = true;
+  group.add(beam);
+
+  const sign = new THREE.Mesh(new THREE.BoxGeometry(2.25, 0.55, 0.12), signMaterial);
+  sign.position.set(0, 2.18, 0.08);
+  sign.castShadow = true;
+  group.add(sign);
+
+  group.position.set(0, 0, VILLAGE.LIBRARY_Z + 7.2);
+  scene.add(group);
+}
+
+function buildLetterPathLanterns(scene: THREE.Scene): void {
+  const postMaterial = new THREE.MeshLambertMaterial({ color: 0x4e3a2b });
+  const paperMaterial = new THREE.MeshLambertMaterial({
+    color: 0xffe3b0,
+    emissive: 0xffb75f,
+    emissiveIntensity: 0.45,
+  });
+  const waxMaterial = new THREE.MeshLambertMaterial({ color: 0xb95e4a });
+  const spots: [number, number][] = [
+    [-2.8, VILLAGE.ENTRY_Z - 20],
+    [2.8, VILLAGE.ENTRY_Z - 23],
+    [-2.8, VILLAGE.CAMPFIRE_Z - 6],
+    [2.8, VILLAGE.CAMPFIRE_Z - 10],
+    [-2.8, VILLAGE.LIBRARY_Z + 14],
+    [2.8, VILLAGE.LIBRARY_Z + 11],
+  ];
+
+  for (const [x, z] of spots) {
+    const group = tagDecor(new THREE.Group(), 'letter-path-lantern');
+    const post = new THREE.Mesh(new THREE.CylinderGeometry(0.045, 0.06, 1.1, 6), postMaterial);
+    post.position.set(0, 0.55, 0);
+    post.castShadow = true;
+    group.add(post);
+
+    const note = new THREE.Mesh(new THREE.BoxGeometry(0.34, 0.28, 0.035), paperMaterial);
+    note.position.set(0, 1.16, 0);
+    note.rotation.z = 0.08;
+    group.add(note);
+
+    const seal = new THREE.Mesh(new THREE.SphereGeometry(0.045, 6, 5), waxMaterial);
+    seal.position.set(0.1, 1.1, 0.025);
+    group.add(seal);
+
+    group.position.set(x, 0, z);
+    group.rotation.y = x < 0 ? 0.22 : -0.22;
+    scene.add(group);
+  }
+}
+
+function buildLibraryFlowerBoxes(scene: THREE.Scene): void {
+  const boxMaterial = new THREE.MeshLambertMaterial({ color: 0x7a5636 });
+  const leafMaterial = new THREE.MeshLambertMaterial({ color: 0x5f8b4a });
+  const petalMaterials = [
+    new THREE.MeshLambertMaterial({ color: 0xf2a0b5 }),
+    new THREE.MeshLambertMaterial({ color: 0xf5d76e }),
+    new THREE.MeshLambertMaterial({ color: 0xc9a0dc }),
+  ];
+
+  for (const x of [-3.9, 3.9]) {
+    const group = tagDecor(new THREE.Group(), 'library-flower-box');
+    const box = new THREE.Mesh(new THREE.BoxGeometry(1.5, 0.32, 0.38), boxMaterial);
+    box.position.set(0, 0.22, 0);
+    box.castShadow = true;
+    group.add(box);
+
+    for (let i = 0; i < 5; i += 1) {
+      const leaf = new THREE.Mesh(new THREE.SphereGeometry(0.16, 7, 5), leafMaterial);
+      leaf.position.set(-0.55 + i * 0.27, 0.48, 0);
+      leaf.scale.set(1.2, 0.7, 0.8);
+      group.add(leaf);
+
+      const petal = new THREE.Mesh(
+        new THREE.SphereGeometry(0.08, 7, 5),
+        petalMaterials[i % petalMaterials.length],
+      );
+      petal.position.set(-0.55 + i * 0.27, 0.64, 0.02);
+      group.add(petal);
+    }
+
+    group.position.set(x, 0, VILLAGE.LIBRARY_Z + 3.9);
+    scene.add(group);
+  }
+}
+
 /** 마을 안쪽 나무 12그루 + 그루터기 4 — 넓어진 잔디가 비어 보이지 않게. */
 function buildInnerTrees(scene: THREE.Scene, rng: () => number): void {
   const trunkMaterial = new THREE.MeshLambertMaterial({ color: 0x5a3d2a });
@@ -513,6 +671,7 @@ export function buildVillageDecor(scene: THREE.Scene): VillageDecor {
   buildInnerTrees(scene, rng);
   buildCampfireHideout(scene);
   buildPathFence(scene);
+  buildFreeMockupSignatureProps(scene);
   const lanterns = buildLanterns(scene);
   const pond = buildPondDetail(scene, rng);
   const campfire = buildCampfireDetail(scene, rng);

--- a/frontend/src/three/scenes/villageDecor.ts
+++ b/frontend/src/three/scenes/villageDecor.ts
@@ -25,10 +25,43 @@ function mulberry32(seed: number): () => number {
 }
 
 const DECOR_SEED = 20260612;
+const COLLISION_CLEARANCE = 0.08;
+
+interface DecorCollider {
+  x: number;
+  z: number;
+  radius: number;
+}
 
 function tagDecor<T extends THREE.Object3D>(obj: T, role: string): T {
   obj.userData.villageDecorRole = role;
   return obj;
+}
+
+function pushCollider(colliders: DecorCollider[], x: number, z: number, radius: number): void {
+  colliders.push({ x, z, radius });
+}
+
+function resolveCircleCollisions(
+  position: THREE.Vector3,
+  colliders: readonly DecorCollider[],
+): void {
+  for (const collider of colliders) {
+    const dx = position.x - collider.x;
+    const dz = position.z - collider.z;
+    const minDistance = collider.radius + COLLISION_CLEARANCE;
+    const distance = Math.hypot(dx, dz);
+    if (distance >= minDistance) continue;
+
+    if (distance === 0) {
+      position.x = collider.x + minDistance;
+      position.z = collider.z;
+      continue;
+    }
+
+    position.x = collider.x + (dx / distance) * minDistance;
+    position.z = collider.z + (dz / distance) * minDistance;
+  }
 }
 
 /** 길·연못·캠프파이어·도서관·입구를 피해서 배치 (걸어다니는 동선 보호). */
@@ -106,7 +139,7 @@ function buildGrassTufts(scene: THREE.Scene, rng: () => number): void {
   }
 }
 
-function buildRocks(scene: THREE.Scene, rng: () => number): void {
+function buildRocks(scene: THREE.Scene, rng: () => number, colliders: DecorCollider[]): void {
   const geometry = new THREE.DodecahedronGeometry(0.4, 0);
   const materials = [
     new THREE.MeshLambertMaterial({ color: 0x9a948a }),
@@ -121,10 +154,11 @@ function buildRocks(scene: THREE.Scene, rng: () => number): void {
     rock.scale.set(0.5 + rng(), 0.4 + rng() * 0.5, 0.5 + rng());
     rock.castShadow = true;
     scene.add(rock);
+    pushCollider(colliders, point.x, point.z, 0.45);
   }
 }
 
-function buildBushes(scene: THREE.Scene, rng: () => number): void {
+function buildBushes(scene: THREE.Scene, rng: () => number, colliders: DecorCollider[]): void {
   const geometry = new THREE.IcosahedronGeometry(0.6, 0);
   const material = new THREE.MeshLambertMaterial({ color: 0x55794a });
   const berryGeometry = new THREE.SphereGeometry(0.06, 6, 5);
@@ -138,6 +172,7 @@ function buildBushes(scene: THREE.Scene, rng: () => number): void {
     bush.scale.set(s, s * 0.8, s);
     bush.castShadow = true;
     scene.add(bush);
+    pushCollider(colliders, point.x, point.z, 0.55 * s);
     // 절반쯤은 열매 — 보면 줍고 싶은 디테일
     if (rng() > 0.5) {
       for (let b = 0; b < 3; b += 1) {
@@ -155,7 +190,7 @@ function buildBushes(scene: THREE.Scene, rng: () => number): void {
 }
 
 /** 입구 길 양옆 낮은 울타리 — "마을에 들어왔다" 는 감각. */
-function buildPathFence(scene: THREE.Scene): void {
+function buildPathFence(scene: THREE.Scene, colliders: DecorCollider[]): void {
   const postGeometry = new THREE.CylinderGeometry(0.07, 0.07, 0.6, 6);
   const railGeometry = new THREE.BoxGeometry(1.9, 0.07, 0.07);
   const woodMaterial = new THREE.MeshLambertMaterial({ color: 0x8a6a48 });
@@ -166,10 +201,12 @@ function buildPathFence(scene: THREE.Scene): void {
       post.position.set(side, 0.3, z);
       post.castShadow = true;
       scene.add(post);
+      pushCollider(colliders, side, z, 0.28);
       const rail = new THREE.Mesh(railGeometry, woodMaterial);
       rail.rotation.y = Math.PI / 2;
       rail.position.set(side, 0.45, z - 1);
       scene.add(rail);
+      pushCollider(colliders, side, z - 1, 0.24);
     }
   }
 }
@@ -428,7 +465,7 @@ function buildLibraryFlowerBoxes(scene: THREE.Scene): void {
 }
 
 /** 마을 안쪽 나무 12그루 + 그루터기 4 — 넓어진 잔디가 비어 보이지 않게. */
-function buildInnerTrees(scene: THREE.Scene, rng: () => number): void {
+function buildInnerTrees(scene: THREE.Scene, rng: () => number, colliders: DecorCollider[]): void {
   const trunkMaterial = new THREE.MeshLambertMaterial({ color: 0x5a3d2a });
   const leafMaterials = [
     new THREE.MeshLambertMaterial({ color: 0x4a7c45 }),
@@ -446,6 +483,7 @@ function buildInnerTrees(scene: THREE.Scene, rng: () => number): void {
     trunk.position.set(point.x, 0.9 * s, point.z);
     trunk.castShadow = true;
     scene.add(trunk);
+    pushCollider(colliders, point.x, point.z, 0.42 * s);
 
     const leafMaterial = leafMaterials[Math.floor(rng() * leafMaterials.length)];
     if (rng() > 0.5) {
@@ -470,6 +508,7 @@ function buildInnerTrees(scene: THREE.Scene, rng: () => number): void {
     stump.position.set(point.x, 0.17, point.z);
     stump.castShadow = true;
     scene.add(stump);
+    pushCollider(colliders, point.x, point.z, 0.4);
   }
 }
 
@@ -754,18 +793,21 @@ function buildFireflies(scene: THREE.Scene, rng: () => number): FireflyResult {
 export interface VillageDecor {
   /** 매 프레임 호출 — elapsed 는 누적 초. 저주파 흔들림만 (D11 점멸 금지). */
   update(elapsed: number): void;
+  /** 두꺼운 절차적 데코(나무·울타리·돌·덤불·그루터기) 원형 충돌 처리. */
+  resolveCollisions(position: THREE.Vector3): void;
 }
 
 export function buildVillageDecor(scene: THREE.Scene): VillageDecor {
   const rng = mulberry32(DECOR_SEED);
+  const colliders: DecorCollider[] = [];
 
   buildFlowers(scene, rng);
   buildGrassTufts(scene, rng);
-  buildRocks(scene, rng);
-  buildBushes(scene, rng);
-  buildInnerTrees(scene, rng);
+  buildRocks(scene, rng, colliders);
+  buildBushes(scene, rng, colliders);
+  buildInnerTrees(scene, rng, colliders);
   buildCampfireHideout(scene);
-  buildPathFence(scene);
+  buildPathFence(scene, colliders);
   buildFreeMockupSignatureProps(scene);
   const lanterns = buildLanterns(scene);
   const pond = buildPondDetail(scene, rng);
@@ -773,6 +815,10 @@ export function buildVillageDecor(scene: THREE.Scene): VillageDecor {
   const fireflies = buildFireflies(scene, rng);
 
   return {
+    resolveCollisions(position: THREE.Vector3): void {
+      resolveCircleCollisions(position, colliders);
+    },
+
     update(elapsed: number): void {
       // 모닥불 — 불씨가 천천히 떠오르며 소멸, 점광은 잔잔히 일렁임
       campfire.fireLight.intensity = 13 + Math.sin(elapsed * 5.3) * 1.6 + Math.sin(elapsed * 9.1);

--- a/frontend/src/three/scenes/villageDecor.ts
+++ b/frontend/src/three/scenes/villageDecor.ts
@@ -176,7 +176,6 @@ function buildPathFence(scene: THREE.Scene): void {
 
 /** 무료/자체 제작 소품 패스 — 외부 유료 에셋 없이 목업의 밀도와 기억점을 만든다. */
 function buildFreeMockupSignatureProps(scene: THREE.Scene): void {
-  buildConfessionMailbox(scene);
   buildLibraryWelcomeArch(scene);
   buildLetterPathLanterns(scene);
   buildLibraryFlowerBoxes(scene);
@@ -186,7 +185,6 @@ function buildFreeMockupSignatureProps(scene: THREE.Scene): void {
 function buildFairyForestHideout(scene: THREE.Scene): void {
   buildFairyMushroomRing(scene);
   buildSecretTrailFlowers(scene);
-  buildHangingLanternGarlands(scene);
   buildGlowStones(scene);
   buildLeafySecretArch(scene);
 }
@@ -281,45 +279,6 @@ function buildSecretTrailFlowers(scene: THREE.Scene): void {
   });
 }
 
-function buildHangingLanternGarlands(scene: THREE.Scene): void {
-  const ropeMaterial = new THREE.MeshLambertMaterial({ color: 0x6b4a32 });
-  const lanternMaterial = new THREE.MeshLambertMaterial({
-    color: 0xffd890,
-    emissive: 0xffaa5a,
-    emissiveIntensity: 0.75,
-  });
-  const leafMaterial = new THREE.MeshLambertMaterial({ color: 0x5f8d52 });
-  const zSpots = [VILLAGE.ENTRY_Z - 14, VILLAGE.CAMPFIRE_Z - 4, VILLAGE.LIBRARY_Z + 13];
-
-  for (const z of zSpots) {
-    const group = tagDecor(new THREE.Group(), 'hanging-lantern-garland');
-    const rope = new THREE.Mesh(new THREE.CylinderGeometry(0.025, 0.025, 5.4, 6), ropeMaterial);
-    rope.rotation.z = Math.PI / 2;
-    rope.position.set(0, 2.25, 0);
-    group.add(rope);
-
-    for (const x of [-1.75, 0, 1.75]) {
-      const drop = new THREE.Mesh(new THREE.CylinderGeometry(0.012, 0.012, 0.45, 5), ropeMaterial);
-      drop.position.set(x, 2.02, 0);
-      group.add(drop);
-
-      const lantern = new THREE.Mesh(new THREE.SphereGeometry(0.18, 8, 6), lanternMaterial);
-      lantern.position.set(x, 1.72, 0);
-      group.add(lantern);
-    }
-
-    for (const x of [-2.25, -0.75, 0.75, 2.25]) {
-      const leaf = new THREE.Mesh(new THREE.SphereGeometry(0.12, 6, 5), leafMaterial);
-      leaf.position.set(x, 2.33, 0);
-      leaf.scale.set(1.5, 0.45, 0.8);
-      group.add(leaf);
-    }
-
-    group.position.set(0, 0, z);
-    scene.add(group);
-  }
-}
-
 function buildGlowStones(scene: THREE.Scene): void {
   const stoneMaterial = new THREE.MeshLambertMaterial({
     color: 0x9fd8ff,
@@ -392,47 +351,6 @@ function buildLeafySecretArch(scene: THREE.Scene): void {
   }
 
   group.position.set(0, 0, VILLAGE.LIBRARY_Z + 9.7);
-  scene.add(group);
-}
-
-function buildConfessionMailbox(scene: THREE.Scene): void {
-  const group = tagDecor(new THREE.Group(), 'confession-mailbox');
-  const redMaterial = new THREE.MeshLambertMaterial({ color: 0xb94b43 });
-  const darkRedMaterial = new THREE.MeshLambertMaterial({ color: 0x81352f });
-  const woodMaterial = new THREE.MeshLambertMaterial({ color: 0x765437 });
-  const creamMaterial = new THREE.MeshLambertMaterial({ color: 0xf4e6c9 });
-
-  const post = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.95, 0.16), woodMaterial);
-  post.position.set(0, 0.48, 0);
-  post.castShadow = true;
-  group.add(post);
-
-  const box = new THREE.Mesh(new THREE.BoxGeometry(1.05, 0.48, 0.58), redMaterial);
-  box.position.set(0, 1.12, 0);
-  box.castShadow = true;
-  group.add(box);
-
-  const roof = new THREE.Mesh(new THREE.CylinderGeometry(0.3, 0.3, 1.06, 12), darkRedMaterial);
-  roof.rotation.z = Math.PI / 2;
-  roof.position.set(0, 1.38, 0);
-  roof.scale.z = 0.72;
-  roof.castShadow = true;
-  group.add(roof);
-
-  const flagPole = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.55, 0.05), woodMaterial);
-  flagPole.position.set(0.58, 1.35, 0.32);
-  group.add(flagPole);
-
-  const flag = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.24, 0.04), creamMaterial);
-  flag.position.set(0.78, 1.55, 0.32);
-  group.add(flag);
-
-  const letterSlot = new THREE.Mesh(new THREE.BoxGeometry(0.62, 0.08, 0.04), creamMaterial);
-  letterSlot.position.set(0, 1.15, 0.31);
-  group.add(letterSlot);
-
-  group.position.set(-3.7, 0, VILLAGE.ENTRY_Z - 16);
-  group.rotation.y = -0.18;
   scene.add(group);
 }
 

--- a/frontend/src/three/scenes/villageDecor.ts
+++ b/frontend/src/three/scenes/villageDecor.ts
@@ -176,7 +176,6 @@ function buildPathFence(scene: THREE.Scene): void {
 
 /** 무료/자체 제작 소품 패스 — 외부 유료 에셋 없이 목업의 밀도와 기억점을 만든다. */
 function buildFreeMockupSignatureProps(scene: THREE.Scene): void {
-  buildLibraryWelcomeArch(scene);
   buildLetterPathLanterns(scene);
   buildLibraryFlowerBoxes(scene);
   buildFairyForestHideout(scene);
@@ -351,41 +350,6 @@ function buildLeafySecretArch(scene: THREE.Scene): void {
   }
 
   group.position.set(0, 0, VILLAGE.LIBRARY_Z + 9.7);
-  scene.add(group);
-}
-
-function buildLibraryWelcomeArch(scene: THREE.Scene): void {
-  const group = tagDecor(new THREE.Group(), 'library-welcome-arch');
-  const woodMaterial = new THREE.MeshLambertMaterial({ color: 0x6f4f34 });
-  const signMaterial = new THREE.MeshLambertMaterial({ color: 0xc99a62 });
-  const glowMaterial = new THREE.MeshLambertMaterial({
-    color: 0xffdf9a,
-    emissive: 0xffb85a,
-    emissiveIntensity: 0.65,
-  });
-
-  for (const x of [-2.35, 2.35]) {
-    const post = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.16, 2.7, 7), woodMaterial);
-    post.position.set(x, 1.35, 0);
-    post.castShadow = true;
-    group.add(post);
-
-    const lantern = new THREE.Mesh(new THREE.SphereGeometry(0.16, 8, 6), glowMaterial);
-    lantern.position.set(x, 2.25, 0.08);
-    group.add(lantern);
-  }
-
-  const beam = new THREE.Mesh(new THREE.BoxGeometry(5.2, 0.18, 0.2), woodMaterial);
-  beam.position.set(0, 2.62, 0);
-  beam.castShadow = true;
-  group.add(beam);
-
-  const sign = new THREE.Mesh(new THREE.BoxGeometry(2.25, 0.55, 0.12), signMaterial);
-  sign.position.set(0, 2.18, 0.08);
-  sign.castShadow = true;
-  group.add(sign);
-
-  group.position.set(0, 0, VILLAGE.LIBRARY_Z + 7.2);
   scene.add(group);
 }
 


### PR DESCRIPTION
﻿## Summary
- restore the V11 Flyway migration checksum by removing post-apply comment edits
- polish library room UX: labeled sign, owl keeper librarian, cleaner dialog controls, furniture and village decor collisions
- remove cluttered village props and document premium low-poly asset options as optional candidates

## Verification
- npm.cmd run lint:md -- docs/wiki/frontend/asset-guide.md
- npm.cmd run test:run -- src/three/scenes/LibraryScene.test.ts src/three/scenes/VillageScene.test.ts src/three/scenes/villageDecor.test.ts src/components/library/LibraryOverlay.test.tsx
- npx.cmd tsc --noEmit
- npm.cmd run build
- .\\gradlew.bat --no-daemon check
- git diff --check

Closes #148

## Notes
- Canvas getContext warnings appear in jsdom scene tests, but assertions pass and browser/Next build succeed.
- docs/reports/asset-mockups/ remains local untracked output and is intentionally excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 도서관과 마을에 충돌 처리와 이동 보정이 적용되어, 캐릭터가 장식물·가구와 더 자연스럽게 상호작용합니다.
  * 마을 도서관 입구 표지판에 새 텍스처가 적용되어 시인성이 개선되었습니다.
  * 숲 은신처 분위기의 신규 비주얼 가이드가 추가되었습니다.

* **Bug Fixes**
  * 책장, 사서, 마을 장식 주변에서 캐릭터가 끼이거나 겹치는 문제가 줄었습니다.
  * 상호작용 버튼과 페이지 이동 버튼의 정렬·크기 일관성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
